### PR TITLE
Add indicator for starred albums/artists in grid

### DIFF
--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -165,6 +165,7 @@ const Card = ({
 
           {hasHoverButtons && (
             <>
+              {rest.details.starred && <div className="corner-triangle" />}
               <PlayOverlayButton
                 size="lg"
                 circle

--- a/src/components/card/styled.tsx
+++ b/src/components/card/styled.tsx
@@ -90,6 +90,19 @@ export const Overlay = styled.div<Card>`
   &:hover {
     cursor: pointer;
   }
+
+  .corner-triangle {
+    position: absolute;
+    background-color: ${(props) => props.theme.primary.main};
+    box-shadow: 0 0 10px 8px rgba(0, 0, 0, 0.8);
+    height: 80px;
+    left: -50px;
+    top: -50px;
+    width: 80px;
+
+    transform: rotate(-45deg);
+    -webkit-transform: rotate(-45deg);
+  }
 `;
 
 const OverlayButton = styled(IconButton)`


### PR DESCRIPTION
Add corner indicator for starred artists/albums
![image](https://user-images.githubusercontent.com/42182408/136688498-a3ee19fa-74b7-4b81-9ab2-a7c2e39c40f4.png)
