### PR TITLE
0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2021-11-09
+
+### Added
+
+- Added additional grid-view customization options (#74)
+  - Gap size (spaces between cards)
+  - Alignment (left-align, center-align)
+
+### Changed
+
+- Changed default album/artist uncached image sizes from `150px` -> `350px`
+
+### Fixed
+
+- (Windows) Fixed default taskbar thumbnail on Windows10 when minimized to use window instead of album cover (#73)
+- Fixed playback settings unable to change via the UI
+  - Crossfade duration
+  - Polling interval
+  - Volume fade
+- Fixed header styling on the Config page breaking at smaller window widths (#72)
+- Fixed the position of the description tooltip on the Artist page
+- Fixed the `Add to playlist` popover showing underneath the modal in modal-view
+
+### Removed
+
+- Removed unused `fonts.size.pageTitle` theme property
+
 ## [0.5.0] - 2021-11-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@
     <img src="https://img.shields.io/github/v/release/jeffvli/sonixd?style=flat-square&color=blue"
     alt="Release">
   </a>
-
   <a href="https://github.com/jeffvli/sonixd/compare/dev">
     <img src="https://img.shields.io/github/commits-since/jeffvli/sonixd/latest/dev?style=flat-square&color=red"
     alt="Commits">
   </a>
   <a href="https://github.com/jeffvli/sonixd/blob/main/LICENSE">
-    <img src="https://img.shields.io/github/license/jeffvli/sonixd?style=flat-square&color=green"
+    <img src="https://img.shields.io/github/license/jeffvli/sonixd?style=flat-square&color=brightgreen"
     alt="License">
+  </a>
+  <a href="https://github.com/jeffvli/sonixd/releases">
+    <img src="https://img.shields.io/github/downloads/jeffvli/sonixd/total?style=flat-square&color=orange"
+    alt="Downloads">
   </a>
 
 Sonixd is a cross-platform desktop client built for Subsonic-API compatible music servers. This project was inspired by the many existing clients, but aimed to address a few key issues including <strong>scalability</strong>, <strong>library management</strong>, and <strong>user experience</strong>.

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -365,6 +365,7 @@ const configState: ConfigPage = {
     },
     gridView: {
       cardSize: 160,
+      alignment: 'flex-start',
     },
   },
 };

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -365,6 +365,7 @@ const configState: ConfigPage = {
     },
     gridView: {
       cardSize: 160,
+      gapSize: 20,
       alignment: 'flex-start',
     },
   },

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -113,7 +113,7 @@ const authParams = {
   f: 'json',
 };
 
-const getCoverArtUrl = (item: any, useLegacyAuth: boolean, size = 150) => {
+const getCoverArtUrl = (item: any, useLegacyAuth: boolean, size?: number) => {
   if (!item.coverArt && !item.artistImageUrl) {
     return 'img/placeholder.jpg';
   }
@@ -127,14 +127,38 @@ const getCoverArtUrl = (item: any, useLegacyAuth: boolean, size = 150) => {
   }
 
   if (useLegacyAuth) {
+    if (!size) {
+      return (
+        `${API_BASE_URL}/getCoverArt` +
+        `?id=${item.coverArt}` +
+        `&u=${auth.username}` +
+        `&s=${auth.salt}` +
+        `&t=${auth.hash}` +
+        `&v=1.15.0` +
+        `&c=sonixd`
+      );
+    }
     return (
       `${API_BASE_URL}/getCoverArt` +
       `?id=${item.coverArt}` +
       `&u=${auth.username}` +
-      `&p=${auth.password}` +
+      `&s=${auth.salt}` +
+      `&t=${auth.hash}` +
       `&v=1.15.0` +
       `&c=sonixd` +
       `&size=${size}`
+    );
+  }
+
+  if (!size) {
+    return (
+      `${API_BASE_URL}/getCoverArt` +
+      `?id=${item.coverArt}` +
+      `&u=${auth.username}` +
+      `&s=${auth.salt}` +
+      `&t=${auth.hash}` +
+      `&v=1.15.0` +
+      `&c=sonixd`
     );
   }
 
@@ -192,7 +216,8 @@ export const getPlaylists = async (sortBy: string) => {
   return (newData || []).map((playlist: any) => ({
     ...playlist,
     name: playlist.name,
-    image: playlist.songCount > 0 ? getCoverArtUrl(playlist, legacyAuth) : 'img/placeholder.jpg',
+    image:
+      playlist.songCount > 0 ? getCoverArtUrl(playlist, legacyAuth, 350) : 'img/placeholder.jpg',
     type: 'playlist',
     uniqueId: nanoid(),
   }));
@@ -206,14 +231,14 @@ export const getPlaylist = async (id: string) => {
     song: (data.playlist.entry || []).map((entry: any, index: any) => ({
       ...entry,
       streamUrl: getStreamUrl(entry.id, legacyAuth),
-      image: getCoverArtUrl(entry, legacyAuth),
+      image: getCoverArtUrl(entry, legacyAuth, 150),
       type: 'music',
       index,
       uniqueId: nanoid(),
     })),
     image:
       data.playlist.songCount > 0
-        ? getCoverArtUrl(data.playlist, legacyAuth)
+        ? getCoverArtUrl(data.playlist, legacyAuth, 350)
         : 'img/placeholder.jpg',
   };
 };
@@ -255,7 +280,7 @@ export const getStarred = async (options: { musicFolderId?: string | number }) =
       ...entry,
       title: entry.name,
       albumId: entry.id,
-      image: getCoverArtUrl(entry, legacyAuth),
+      image: getCoverArtUrl(entry, legacyAuth, 350),
       starred: entry.starred || undefined,
       type: 'album',
       isDir: false,
@@ -265,7 +290,7 @@ export const getStarred = async (options: { musicFolderId?: string | number }) =
     song: (data.starred2.song || []).map((entry: any, index: any) => ({
       ...entry,
       streamUrl: getStreamUrl(entry.id, legacyAuth),
-      image: getCoverArtUrl(entry, legacyAuth),
+      image: getCoverArtUrl(entry, legacyAuth, 150),
       starred: entry.starred || undefined,
       type: 'music',
       index,
@@ -275,7 +300,7 @@ export const getStarred = async (options: { musicFolderId?: string | number }) =
       ...entry,
       albumCount: entry.albumCount || undefined,
       coverArt: getCoverArtUrl(entry, legacyAuth),
-      image: getCoverArtUrl(entry, legacyAuth),
+      image: getCoverArtUrl(entry, legacyAuth, 350),
       starred: entry.starred || Date.now(), // Airsonic does not return the starred date
       type: 'artist',
       index,
@@ -284,28 +309,25 @@ export const getStarred = async (options: { musicFolderId?: string | number }) =
   };
 };
 
-export const getAlbums = async (
-  options: {
-    type:
-      | 'random'
-      | 'newest'
-      | 'highest'
-      | 'frequent'
-      | 'recent'
-      | 'alphabeticalByName'
-      | 'alphabeticalByArtist'
-      | 'starred'
-      | 'byYear'
-      | 'byGenre';
-    size?: number;
-    offset?: number;
-    fromYear?: number;
-    toYear?: number;
-    genre?: string;
-    musicFolderId?: string | number;
-  },
-  coverArtSize = 150
-) => {
+export const getAlbums = async (options: {
+  type:
+    | 'random'
+    | 'newest'
+    | 'highest'
+    | 'frequent'
+    | 'recent'
+    | 'alphabeticalByName'
+    | 'alphabeticalByArtist'
+    | 'starred'
+    | 'byYear'
+    | 'byGenre';
+  size?: number;
+  offset?: number;
+  fromYear?: number;
+  toYear?: number;
+  genre?: string;
+  musicFolderId?: string | number;
+}) => {
   const { data } = await api.get(`/getAlbumList2`, {
     params: options,
   });
@@ -316,7 +338,7 @@ export const getAlbums = async (
       ...entry,
       title: entry.name,
       albumId: entry.id,
-      image: getCoverArtUrl(entry, legacyAuth, coverArtSize),
+      image: getCoverArtUrl(entry, legacyAuth, 350),
       starred: entry.starred || undefined,
       type: 'album',
       isDir: false,
@@ -326,28 +348,25 @@ export const getAlbums = async (
   };
 };
 
-export const getAlbumsDirect = async (
-  options: {
-    type:
-      | 'random'
-      | 'newest'
-      | 'highest'
-      | 'frequent'
-      | 'recent'
-      | 'alphabeticalByName'
-      | 'alphabeticalByArtist'
-      | 'starred'
-      | 'byYear'
-      | 'byGenre';
-    size?: number;
-    offset?: number;
-    fromYear?: number;
-    toYear?: number;
-    genre?: string;
-    musicFolderId?: string | number;
-  },
-  coverArtSize = 150
-) => {
+export const getAlbumsDirect = async (options: {
+  type:
+    | 'random'
+    | 'newest'
+    | 'highest'
+    | 'frequent'
+    | 'recent'
+    | 'alphabeticalByName'
+    | 'alphabeticalByArtist'
+    | 'starred'
+    | 'byYear'
+    | 'byGenre';
+  size?: number;
+  offset?: number;
+  fromYear?: number;
+  toYear?: number;
+  genre?: string;
+  musicFolderId?: string | number;
+}) => {
   const { data } = await api.get(`/getAlbumList2`, {
     params: options,
   });
@@ -356,7 +375,7 @@ export const getAlbumsDirect = async (
     ...entry,
     title: entry.name,
     albumId: entry.id,
-    image: getCoverArtUrl(entry, legacyAuth, coverArtSize),
+    image: getCoverArtUrl(entry, legacyAuth, 350),
     starred: entry.starred || undefined,
     type: 'album',
     isDir: false,
@@ -388,8 +407,7 @@ export const getAllAlbums = (
     genre?: string;
     musicFolderId?: string | number;
   },
-  data: any[] = [],
-  coverArtSize = 150
+  data: any[] = []
 ) => {
   const albums: any = api
     .get(`/getAlbumList2`, {
@@ -413,7 +431,7 @@ export const getAllAlbums = (
           ...entry,
           title: entry.name,
           albumId: entry.id,
-          image: getCoverArtUrl(entry, legacyAuth, coverArtSize),
+          image: getCoverArtUrl(entry, legacyAuth, 350),
           starred: entry.starred || undefined,
           type: 'album',
           isDir: false,
@@ -439,7 +457,7 @@ export const getAllAlbums = (
   return albums;
 };
 
-export const getAlbum = async (id: string, coverArtSize = 150) => {
+export const getAlbum = async (id: string) => {
   const { data } = await api.get(`/getAlbum`, {
     params: {
       id,
@@ -448,13 +466,13 @@ export const getAlbum = async (id: string, coverArtSize = 150) => {
 
   return {
     ...data.album,
-    image: getCoverArtUrl(data.album, legacyAuth, coverArtSize),
+    image: getCoverArtUrl(data.album, legacyAuth, 350),
     type: 'album',
     isDir: false,
     song: (data.album.song || []).map((entry: any, index: any) => ({
       ...entry,
       streamUrl: getStreamUrl(entry.id, legacyAuth),
-      image: getCoverArtUrl(entry, legacyAuth, coverArtSize),
+      image: getCoverArtUrl(entry, legacyAuth, 150),
       type: 'music',
       starred: entry.starred || undefined,
       index,
@@ -463,16 +481,13 @@ export const getAlbum = async (id: string, coverArtSize = 150) => {
   };
 };
 
-export const getRandomSongs = async (
-  options: {
-    size?: number;
-    genre?: string;
-    fromYear?: number;
-    toYear?: number;
-    musicFolderId?: number;
-  },
-  coverArtSize = 150
-) => {
+export const getRandomSongs = async (options: {
+  size?: number;
+  genre?: string;
+  fromYear?: number;
+  toYear?: number;
+  musicFolderId?: number;
+}) => {
   const { data } = await api.get(`/getRandomSongs`, {
     params: options,
   });
@@ -482,7 +497,7 @@ export const getRandomSongs = async (
     song: (data.randomSongs.song || []).map((entry: any, index: any) => ({
       ...entry,
       streamUrl: getStreamUrl(entry.id, legacyAuth),
-      image: getCoverArtUrl(entry, legacyAuth, coverArtSize),
+      image: getCoverArtUrl(entry, legacyAuth, 150),
       starred: entry.starred || undefined,
       index,
       uniqueId: nanoid(),
@@ -501,7 +516,7 @@ export const getArtists = async (options: { musicFolderId?: string | number }) =
   artists.map((artist: any) =>
     artistList.push({
       ...artist,
-      image: getCoverArtUrl(artist, legacyAuth, 150),
+      image: getCoverArtUrl(artist, legacyAuth, 350),
       type: 'artist',
       uniqueId: nanoid(),
     })
@@ -510,7 +525,7 @@ export const getArtists = async (options: { musicFolderId?: string | number }) =
   return artistList;
 };
 
-export const getArtist = async (id: string, coverArtSize = 150) => {
+export const getArtist = async (id: string) => {
   const { data } = await api.get(`/getArtist`, {
     params: {
       id,
@@ -519,14 +534,14 @@ export const getArtist = async (id: string, coverArtSize = 150) => {
 
   return {
     ...data.artist,
-    image: getCoverArtUrl(data.artist, legacyAuth, coverArtSize),
+    image: getCoverArtUrl(data.artist, legacyAuth, 350),
     type: 'artist',
     album: (data.artist.album || []).map((entry: any, index: any) => ({
       ...entry,
       albumId: entry.id,
       type: 'album',
       isDir: false,
-      image: getCoverArtUrl(entry, legacyAuth, coverArtSize),
+      image: getCoverArtUrl(entry, legacyAuth, 350),
       starred: entry.starred || undefined,
       index,
       uniqueId: nanoid(),
@@ -686,7 +701,7 @@ export const setRating = async (id: string, rating: number) => {
   return data;
 };
 
-export const getSimilarSongs = async (id: string, count: number, coverArtSize = 150) => {
+export const getSimilarSongs = async (id: string, count: number) => {
   const { data } = await api.get(`/getSimilarSongs2`, {
     params: { id, count },
   });
@@ -694,7 +709,7 @@ export const getSimilarSongs = async (id: string, count: number, coverArtSize = 
   return {
     song: (data.similarSongs2.song || []).map((entry: any, index: any) => ({
       ...entry,
-      image: getCoverArtUrl(entry, legacyAuth, coverArtSize),
+      image: getCoverArtUrl(entry, legacyAuth, 150),
       index,
       uniqueId: nanoid(),
     })),
@@ -827,7 +842,7 @@ export const search3 = async (options: {
   return {
     artist: (results.artist || []).map((entry: any, index: any) => ({
       ...entry,
-      image: getCoverArtUrl(entry, legacyAuth),
+      image: getCoverArtUrl(entry, legacyAuth, 350),
       starred: entry.starred || undefined,
       type: 'artist',
       index,
@@ -836,7 +851,7 @@ export const search3 = async (options: {
     album: (results.album || []).map((entry: any, index: any) => ({
       ...entry,
       albumId: entry.id,
-      image: getCoverArtUrl(entry, legacyAuth),
+      image: getCoverArtUrl(entry, legacyAuth, 350),
       starred: entry.starred || undefined,
       type: 'album',
       isDir: false,
@@ -846,7 +861,7 @@ export const search3 = async (options: {
     song: (results.song || []).map((entry: any, index: any) => ({
       ...entry,
       streamUrl: getStreamUrl(entry.id, legacyAuth),
-      image: getCoverArtUrl(entry, legacyAuth),
+      image: getCoverArtUrl(entry, legacyAuth, 150),
       type: 'music',
       starred: entry.starred || undefined,
       index,
@@ -878,7 +893,7 @@ export const getIndexes = async (options: {
         ...folder,
         title: folder.name,
         isDir: true,
-        image: getCoverArtUrl(folder, legacyAuth),
+        image: getCoverArtUrl(folder, legacyAuth, 150),
         uniqueId: nanoid(),
         type: 'folder',
       });
@@ -894,7 +909,7 @@ export const getIndexes = async (options: {
       index,
       type: 'music',
       streamUrl: getStreamUrl(song.id, legacyAuth),
-      image: getCoverArtUrl(song, legacyAuth),
+      image: getCoverArtUrl(song, legacyAuth, 150),
       uniqueId: nanoid(),
     })
   );
@@ -920,7 +935,7 @@ export const getMusicDirectory = async (options: { id: string }) => {
   (folders || []).forEach((folder: any) =>
     child.push({
       ...folder,
-      image: getCoverArtUrl(folder, legacyAuth),
+      image: getCoverArtUrl(folder, legacyAuth, 150),
       uniqueId: nanoid(),
       type: 'folder',
     })
@@ -932,7 +947,7 @@ export const getMusicDirectory = async (options: { id: string }) => {
       index,
       type: 'music',
       streamUrl: getStreamUrl(song.id, legacyAuth),
-      image: getCoverArtUrl(song, legacyAuth),
+      image: getCoverArtUrl(song, legacyAuth, 150),
       uniqueId: nanoid(),
     })
   );
@@ -955,7 +970,7 @@ export const getAllDirectorySongs = async (options: { id: string }, data: any[] 
             index,
             type: 'music',
             streamUrl: getStreamUrl(entry.id, legacyAuth),
-            image: getCoverArtUrl(entry, legacyAuth),
+            image: getCoverArtUrl(entry, legacyAuth, 150),
             uniqueId: nanoid(),
           });
         }

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -29,22 +29,22 @@ const Dashboard = () => {
 
   const { isLoading: isLoadingRecent, data: recentAlbums }: any = useQuery(
     ['recentAlbums', musicFolder],
-    () => getAlbums({ type: 'recent', size: 20, musicFolderId: musicFolder }, 250)
+    () => getAlbums({ type: 'recent', size: 20, musicFolderId: musicFolder })
   );
 
   const { isLoading: isLoadingNewest, data: newestAlbums }: any = useQuery(
     ['newestAlbums', musicFolder],
-    () => getAlbums({ type: 'newest', size: 20, musicFolderId: musicFolder }, 250)
+    () => getAlbums({ type: 'newest', size: 20, musicFolderId: musicFolder })
   );
 
   const { isLoading: isLoadingRandom, data: randomAlbums }: any = useQuery(
     ['randomAlbums', musicFolder],
-    () => getAlbums({ type: 'random', size: 20, musicFolderId: musicFolder }, 250)
+    () => getAlbums({ type: 'random', size: 20, musicFolderId: musicFolder })
   );
 
   const { isLoading: isLoadingFrequent, data: frequentAlbums }: any = useQuery(
     ['frequentAlbums', musicFolder],
-    () => getAlbums({ type: 'frequent', size: 20, musicFolderId: musicFolder }, 250)
+    () => getAlbums({ type: 'frequent', size: 20, musicFolderId: musicFolder })
   );
 
   const handleFavorite = async (rowData: any) => {

--- a/src/components/layout/GenericPageHeader.tsx
+++ b/src/components/layout/GenericPageHeader.tsx
@@ -217,6 +217,8 @@ const GenericPageHeader = ({
             display: 'flex',
             justifyContent: 'space-between',
             height: '50%',
+            whiteSpace: 'nowrap',
+            overflow: 'visible',
           }}
         >
           <PageHeaderSubtitleWrapper>{subtitle}</PageHeaderSubtitleWrapper>

--- a/src/components/layout/GenericPageHeader.tsx
+++ b/src/components/layout/GenericPageHeader.tsx
@@ -107,23 +107,6 @@ const GenericPageHeader = ({
             </CustomImageGrid>
           </CustomImageGridWrapper>
         </CoverArtWrapper>
-        /*         <CoverArtWrapper>
-          <LazyLoadImage
-            src={image[0]}
-            alt="header-img"
-            height={imageHeight || '195px'}
-            width={imageHeight || '195px'}
-            visibleByDefault
-            afterLoad={() => {
-              if (cacheImages.enabled) {
-                cacheImage(
-                  `${cacheImages.cacheType}_${cacheImages.id}.jpg`,
-                  image[0].replace(/size=\d+/, 'size=500')
-                );
-              }
-            }}
-          />
-        </CoverArtWrapper> */
       )}
 
       <PageHeaderWrapper isDark={isDark} hasImage={image} imageHeight={imageHeight || 195}>

--- a/src/components/layout/styled.tsx
+++ b/src/components/layout/styled.tsx
@@ -208,8 +208,8 @@ export const PageHeaderTitle = styled.h1`
   overflow: hidden;
   font-size: 4vw;
 
-  @media screen and (min-width: 1280px) {
-    font-size: 48px;
+  @media screen and (min-width: 1000px) {
+    font-size: 40px;
   }
 `;
 

--- a/src/components/library/ArtistView.tsx
+++ b/src/components/library/ArtistView.tsx
@@ -263,20 +263,20 @@ const ArtistView = ({ ...rest }: any) => {
                   <strong>ARTIST</strong> • {data.albumCount} albums • {artistSongTotal} songs •{' '}
                   {artistDurationTotal}
                 </PageHeaderSubtitleDataLine>
-                <PageHeaderSubtitleDataLine
-                  style={{
-                    minHeight: '2.5rem',
-                    maxHeight: '2.5rem',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'pre-wrap',
-                  }}
+                <CustomTooltip
+                  text={artistInfo?.biography
+                    ?.replace(/<[^>]*>/, '')
+                    .replace('Read more on Last.fm</a>', '')}
+                  placement="bottomStart"
                 >
-                  <CustomTooltip
-                    text={artistInfo?.biography
-                      ?.replace(/<[^>]*>/, '')
-                      .replace('Read more on Last.fm</a>', '')}
-                    placement="bottomStart"
+                  <PageHeaderSubtitleDataLine
+                    style={{
+                      minHeight: '2.5rem',
+                      maxHeight: '2.5rem',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'pre-wrap',
+                    }}
                   >
                     <span>
                       {artistInfo?.biography
@@ -288,8 +288,8 @@ const ArtistView = ({ ...rest }: any) => {
                             .replace('Read more on Last.fm</a>', '')}`
                         : 'No artist biography found'}
                     </span>
-                  </CustomTooltip>
-                </PageHeaderSubtitleDataLine>
+                  </PageHeaderSubtitleDataLine>
+                </CustomTooltip>
 
                 <div style={{ marginTop: '10px' }}>
                   <ButtonToolbar>

--- a/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
+++ b/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
@@ -31,7 +31,12 @@ import {
   genreColumnPicker,
   genreColumnListAuto,
 } from '../ListViewColumns';
-import { setActive, setGridAlignment, setGridCardSize } from '../../../redux/configSlice';
+import {
+  setActive,
+  setGridAlignment,
+  setGridCardSize,
+  setGridGapSize,
+} from '../../../redux/configSlice';
 
 const LookAndFeelConfig = () => {
   const dispatch = useAppDispatch();
@@ -271,7 +276,7 @@ const LookAndFeelConfig = () => {
         </StyledCheckbox>
       </ConfigPanel>
       <ConfigPanel header="Grid-View" bordered>
-        <ControlLabel>Card size</ControlLabel>
+        <ControlLabel>Card size (px)</ControlLabel>
         <StyledInputNumber
           defaultValue={config.lookAndFeel.gridView.cardSize}
           step={1}
@@ -281,6 +286,19 @@ const LookAndFeelConfig = () => {
           onChange={(e: any) => {
             settings.setSync('gridCardSize', Number(e));
             dispatch(setGridCardSize({ size: Number(e) }));
+          }}
+        />
+        <br />
+        <ControlLabel>Gap size (px)</ControlLabel>
+        <StyledInputNumber
+          defaultValue={config.lookAndFeel.gridView.gapSize}
+          step={1}
+          min={0}
+          max={100}
+          width={150}
+          onChange={(e: any) => {
+            settings.setSync('gridGapSize', Number(e));
+            dispatch(setGridGapSize({ size: Number(e) }));
           }}
         />
         <br />

--- a/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
+++ b/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import _ from 'lodash';
 import { shell } from 'electron';
 import settings from 'electron-settings';
-import { ControlLabel, Nav, Icon } from 'rsuite';
+import { ControlLabel, Nav, Icon, RadioGroup } from 'rsuite';
 import { ConfigPanel } from '../styled';
 import {
   StyledInputPicker,
@@ -13,6 +13,7 @@ import {
   StyledLink,
   StyledInputGroup,
   StyledInputGroupButton,
+  StyledRadio,
 } from '../../shared/styled';
 import ListViewConfig from './ListViewConfig';
 import { Fonts } from '../Fonts';
@@ -30,7 +31,7 @@ import {
   genreColumnPicker,
   genreColumnListAuto,
 } from '../ListViewColumns';
-import { setActive, setGridCardSize } from '../../../redux/configSlice';
+import { setActive, setGridAlignment, setGridCardSize } from '../../../redux/configSlice';
 
 const LookAndFeelConfig = () => {
   const dispatch = useAppDispatch();
@@ -282,6 +283,21 @@ const LookAndFeelConfig = () => {
             dispatch(setGridCardSize({ size: Number(e) }));
           }}
         />
+        <br />
+        <ControlLabel>Grid alignment</ControlLabel>
+        <RadioGroup
+          name="gridAlignemntRadioList"
+          appearance="default"
+          defaultValue={config.lookAndFeel.gridView.alignment}
+          value={config.lookAndFeel.gridView.alignment}
+          onChange={(e: string) => {
+            dispatch(setGridAlignment({ alignment: e }));
+            settings.setSync('gridAlignment', e);
+          }}
+        >
+          <StyledRadio value="flex-start">Left</StyledRadio>
+          <StyledRadio value="center">Center</StyledRadio>
+        </RadioGroup>
       </ConfigPanel>
     </>
   );

--- a/src/components/settings/ConfigPanels/PlaybackConfig.tsx
+++ b/src/components/settings/ConfigPanels/PlaybackConfig.tsx
@@ -25,6 +25,7 @@ const PlaybackConfig = () => {
   const crossfadePickerContainerRef = useRef(null);
 
   const handleSetCrossfadeDuration = (e: number) => {
+    setCrossfadeDuration(e);
     settings.setSync('fadeDuration', Number(e));
     dispatch(
       setPlaybackSetting({
@@ -40,6 +41,7 @@ const PlaybackConfig = () => {
   };
 
   const handleSetPollingInterval = (e: number) => {
+    setPollingInterval(e);
     settings.setSync('pollingInterval', Number(e));
     dispatch(
       setPlaybackSetting({
@@ -50,6 +52,7 @@ const PlaybackConfig = () => {
   };
 
   const handleSetVolumeFade = (e: boolean) => {
+    setVolumeFade(e);
     settings.setSync('volumeFade', e);
     dispatch(setPlaybackSetting({ setting: 'volumeFade', value: e }));
   };

--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -126,6 +126,10 @@ const setDefaultSettings = (force: boolean) => {
     settings.setSync('gridCardSize', 175);
   }
 
+  if (force || !settings.hasSync('gridGapSize')) {
+    settings.setSync('gridGapSize', 20);
+  }
+
   if (force || !settings.hasSync('gridAlignment')) {
     settings.setSync('gridAlignment', 'flex-start');
   }

--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -126,6 +126,10 @@ const setDefaultSettings = (force: boolean) => {
     settings.setSync('gridCardSize', 175);
   }
 
+  if (force || !settings.hasSync('gridAlignment')) {
+    settings.setSync('gridAlignment', 'flex-start');
+  }
+
   if (force || !settings.hasSync('playlistViewType')) {
     settings.setSync('playlistViewType', 'list');
   }

--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -476,7 +476,6 @@ const setDefaultSettings = (force: boolean) => {
       fonts: {
         size: {
           page: '14px',
-          pageTitle: '40px',
           panelTitle: '20px',
         },
       },
@@ -640,7 +639,6 @@ const setDefaultSettings = (force: boolean) => {
       fonts: {
         size: {
           page: '14px',
-          pageTitle: '30px',
           panelTitle: '20px',
         },
       },

--- a/src/components/shared/styled.ts
+++ b/src/components/shared/styled.ts
@@ -433,7 +433,7 @@ export const ContextMenuPopover = styled(Popover)`
   color: ${(props) => props.theme.colors.contextMenu.color} !important;
   background: ${(props) => props.theme.colors.contextMenu.background};
   position: absolute;
-  z-index: 1000;
+  z-index: 2000;
 `;
 
 export const StyledPopover = styled(Popover)`

--- a/src/components/viewtypes/GridViewType.tsx
+++ b/src/components/viewtypes/GridViewType.tsx
@@ -22,8 +22,6 @@ const GridCard = ({ data, index, style }: any) => {
           height: cardHeight,
           margin: `0 ${gapSize / 2}px`,
           display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
           // This allows immediate pointer events after scrolling to override the default delay
           // https://github.com/bvaughn/react-window/issues/128#issuecomment-460166682
           pointerEvents: 'auto',
@@ -65,7 +63,7 @@ const GridCard = ({ data, index, style }: any) => {
         ...style,
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'center',
+        justifyContent: data.alignment,
       }}
     >
       {cards}
@@ -79,6 +77,7 @@ function ListWrapper({
   cardSubtitle,
   playClick,
   size,
+  alignment,
   height,
   itemCount,
   width,
@@ -88,8 +87,8 @@ function ListWrapper({
   handleFavorite,
 }: any) {
   const gapSize = 5;
-  const cardHeight = size + 75; // 225
-  const cardWidth = size + 25; // 175
+  const cardHeight = size + 75;
+  const cardWidth = size + 25;
   // How many cards can we show per row, given the current width?
   const columnCount = Math.floor((width - gapSize) / (cardWidth + gapSize));
   const rowCount = Math.ceil(itemCount / columnCount);
@@ -101,6 +100,7 @@ function ListWrapper({
       cardSubtitle,
       playClick,
       size,
+      alignment,
       columnCount,
       itemCount,
       cacheType,
@@ -122,6 +122,7 @@ function ListWrapper({
       itemCount,
       playClick,
       size,
+      alignment,
       cacheImages,
       cachePath,
       handleFavorite,
@@ -153,6 +154,7 @@ const GridViewType = ({
 }: any) => {
   const cacheImages = Boolean(settings.getSync('cacheImages'));
   const misc = useAppSelector((state) => state.misc);
+  const config = useAppSelector((state) => state.config);
 
   return (
     <AutoSizer>
@@ -166,6 +168,7 @@ const GridViewType = ({
           cardSubtitle={cardSubtitle}
           playClick={playClick}
           size={size}
+          alignment={config.lookAndFeel.gridView.alignment}
           cacheType={cacheType}
           cacheImages={cacheImages}
           cachePath={misc.imageCachePath}

--- a/src/components/viewtypes/GridViewType.tsx
+++ b/src/components/viewtypes/GridViewType.tsx
@@ -77,6 +77,7 @@ function ListWrapper({
   cardSubtitle,
   playClick,
   size,
+  gapSize,
   alignment,
   height,
   itemCount,
@@ -86,11 +87,10 @@ function ListWrapper({
   cachePath,
   handleFavorite,
 }: any) {
-  const gapSize = 5;
-  const cardHeight = size + 75;
-  const cardWidth = size + 25;
+  const cardHeight = size + 55;
+  const cardWidth = size;
   // How many cards can we show per row, given the current width?
-  const columnCount = Math.floor((width - gapSize) / (cardWidth + gapSize));
+  const columnCount = Math.floor((width - gapSize + 3) / (cardWidth + gapSize + 2));
   const rowCount = Math.ceil(itemCount / columnCount);
 
   const itemData = useMemo(
@@ -122,6 +122,7 @@ function ListWrapper({
       itemCount,
       playClick,
       size,
+      gapSize,
       alignment,
       cacheImages,
       cachePath,
@@ -168,6 +169,7 @@ const GridViewType = ({
           cardSubtitle={cardSubtitle}
           playClick={playClick}
           size={size}
+          gapSize={config.lookAndFeel.gridView.gapSize}
           alignment={config.lookAndFeel.gridView.alignment}
           cacheType={cacheType}
           cacheImages={cacheImages}

--- a/src/main.dev.js
+++ b/src/main.dev.js
@@ -12,6 +12,7 @@ import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import Player from 'mpris-service';
 import path from 'path';
+import os from 'os';
 import settings from 'electron-settings';
 import { ipcMain, app, BrowserWindow, shell, globalShortcut, Menu, Tray } from 'electron';
 import electronLocalshortcut from 'electron-localshortcut';
@@ -37,6 +38,7 @@ settings.configure({
 });
 
 const isWindows = process.platform === 'win32';
+const isWindows10 = os.release().match(/^10\.*/g);
 const isMacOS = process.platform === 'darwin';
 const isLinux = process.platform === 'linux';
 
@@ -367,6 +369,21 @@ const createWindow = async () => {
     if (settings.getSync('minimizeToTray')) {
       event.preventDefault();
       mainWindow.hide();
+    }
+
+    if (isWindows && isWindows10) {
+      mainWindow.setThumbnailClip({
+        x: 0,
+        y: 0,
+        height: 0,
+        width: 0,
+      });
+    }
+  });
+
+  mainWindow.on('restore', () => {
+    if (isWindows && isWindows10) {
+      createWinThumbnailClip();
     }
   });
 

--- a/src/redux/configSlice.ts
+++ b/src/redux/configSlice.ts
@@ -37,6 +37,7 @@ export interface ConfigPage {
     };
     gridView: {
       cardSize: number;
+      alignment: string | 'flex-start' | 'center';
     };
   };
 }
@@ -120,6 +121,7 @@ const initialState: ConfigPage = {
     },
     gridView: {
       cardSize: Number(parsedSettings.gridCardSize),
+      alignment: String(parsedSettings.gridAlignment),
     },
   },
 };
@@ -195,6 +197,13 @@ const configSlice = createSlice({
       state.lookAndFeel.gridView.cardSize = action.payload.size;
     },
 
+    setGridAlignment: (
+      state,
+      action: PayloadAction<{ alignment: string | 'flex-start' | 'center' }>
+    ) => {
+      state.lookAndFeel.gridView.alignment = action.payload.alignment;
+    },
+
     moveToIndex: (
       state,
       action: PayloadAction<{
@@ -223,6 +232,7 @@ export const {
   setRowHeight,
   setFontSize,
   setGridCardSize,
+  setGridAlignment,
   moveToIndex,
 } = configSlice.actions;
 export default configSlice.reducer;

--- a/src/redux/configSlice.ts
+++ b/src/redux/configSlice.ts
@@ -37,6 +37,7 @@ export interface ConfigPage {
     };
     gridView: {
       cardSize: number;
+      gapSize: number;
       alignment: string | 'flex-start' | 'center';
     };
   };
@@ -121,6 +122,7 @@ const initialState: ConfigPage = {
     },
     gridView: {
       cardSize: Number(parsedSettings.gridCardSize),
+      gapSize: Number(parsedSettings.gridGapSize),
       alignment: String(parsedSettings.gridAlignment),
     },
   },
@@ -197,6 +199,10 @@ const configSlice = createSlice({
       state.lookAndFeel.gridView.cardSize = action.payload.size;
     },
 
+    setGridGapSize: (state, action: PayloadAction<{ size: number }>) => {
+      state.lookAndFeel.gridView.gapSize = action.payload.size;
+    },
+
     setGridAlignment: (
       state,
       action: PayloadAction<{ alignment: string | 'flex-start' | 'center' }>
@@ -232,6 +238,7 @@ export const {
   setRowHeight,
   setFontSize,
   setGridCardSize,
+  setGridGapSize,
   setGridAlignment,
   moveToIndex,
 } = configSlice.actions;

--- a/src/shared/mockSettings.ts
+++ b/src/shared/mockSettings.ts
@@ -32,6 +32,7 @@ export const mockSettings = {
     starred: false,
   },
   gridCardSize: 200,
+  gridAlignment: 'flex-start',
   playlistViewType: 'grid',
   albumViewType: 'grid',
   musicListFontSize: 13,

--- a/src/shared/mockSettings.ts
+++ b/src/shared/mockSettings.ts
@@ -32,6 +32,7 @@ export const mockSettings = {
     starred: false,
   },
   gridCardSize: 200,
+  gridGapSize: 20,
   gridAlignment: 'flex-start',
   playlistViewType: 'grid',
   albumViewType: 'grid',

--- a/src/styles/styledTheme.ts
+++ b/src/styles/styledTheme.ts
@@ -4,9 +4,7 @@ export const defaultDark = {
   fonts: {
     size: {
       page: '14px',
-      pageTitle: '40px',
       panelTitle: '20px',
-      button: '14px',
     },
   },
   colors: {


### PR DESCRIPTION
### Added

- Added additional grid-view customization options (#74)
  - Gap size (spaces between cards)
  - Alignment (left-align, center-align)

### Changed

- Changed default album/artist uncached image sizes from `150px` -> `350px`

### Fixed

- (Windows) Fixed default taskbar thumbnail on Windows10 when minimized to use window instead of album cover (#73)
- Fixed playback settings unable to change via the UI
  - Crossfade duration
  - Polling interval
  - Volume fade
- Fixed header styling on the Config page breaking at smaller window widths (#72)
- Fixed the position of the description tooltip on the Artist page
- Fixed the `Add to playlist` popover showing underneath the modal in modal-view