### PR TITLE
Add API controller, types, initial jellyfin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,21 @@ You can install sonixd by downloading the [latest release](https://github.com/je
 - Windows: `.exe`
 - Linux: `.AppImage`
 - MacOS: `.dmg`
+---
+### Arch Linux
 
+There is an AUR package of the latest AppImage release available [here](https://aur.archlinux.org/packages/sonixd-appimage).
+
+To install it you can use your favourite AUR package manager and install the package: `sonixd-appimage`
+
+For example using `yay`:
+```
+yay -S sonixd-appimage
+```
+
+If you encounter any problems please comment on the [AUR](https://aur.archlinux.org/packages/sonixd-appimage) or contact the [maintainer](mailto:robin@blckct.io) directly before you open an issue here.
+
+---
 Once installed, run the application and sign in to your music server with the following details. If you are using [airsonic-advanced](https://github.com/airsonic-advanced/airsonic-advanced), you will need to make sure that you create a `decodable` credential for your login user within the admin control panel.
 
 - Server - `e.g. http://localhost:4040/`

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -13,7 +13,7 @@ import { FolderSelection } from '../redux/folderSlice';
 import { FavoritePage } from '../redux/favoriteSlice';
 import App from '../App';
 import { AlbumPage } from '../redux/albumSlice';
-import { Server } from '../api/types';
+import { Server } from '../types';
 
 const middlewares: Middleware<Record<string, unknown>, any, Dispatch<AnyAction>>[] | undefined = [];
 const mockStore = configureMockStore(middlewares);

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -13,6 +13,7 @@ import { FolderSelection } from '../redux/folderSlice';
 import { FavoritePage } from '../redux/favoriteSlice';
 import App from '../App';
 import { AlbumPage } from '../redux/albumSlice';
+import { Server } from '../api/types';
 
 const middlewares: Middleware<Record<string, unknown>, any, Dispatch<AnyAction>>[] | undefined = [];
 const mockStore = configureMockStore(middlewares);
@@ -115,6 +116,7 @@ const configState: ConfigPage = {
     filters: [],
   },
   sort: {},
+  serverType: Server.Subsonic,
   lookAndFeel: {
     listView: {
       music: {

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -220,7 +220,7 @@ const configState: ConfigPage = {
           },
           {
             id: 'Title',
-            dataKey: 'name',
+            dataKey: 'title',
             alignment: 'left',
             flexGrow: 5,
             label: 'Title',
@@ -276,11 +276,11 @@ const configState: ConfigPage = {
             label: 'CoverArt',
           },
           {
-            id: 'Name',
-            dataKey: 'name',
+            id: 'Title',
+            dataKey: 'title',
             alignment: 'left',
             flexGrow: 5,
-            label: 'Name',
+            label: 'Title',
           },
           {
             id: 'Albums',
@@ -311,11 +311,11 @@ const configState: ConfigPage = {
             label: '#',
           },
           {
-            id: 'Name',
-            dataKey: 'name',
+            id: 'Title',
+            dataKey: 'title',
             alignment: 'left',
             flexGrow: 5,
-            label: 'Name',
+            label: 'Tame',
           },
           {
             id: 'Albums',

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -5,7 +5,7 @@ import settings from 'electron-settings';
 import { nanoid } from 'nanoid/non-secure';
 import axiosRetry from 'axios-retry';
 import { mockSettings } from '../shared/mockSettings';
-import { Item } from './types';
+import { Item } from '../types';
 
 const legacyAuth =
   process.env.NODE_ENV === 'test'
@@ -120,11 +120,11 @@ const getCoverArtUrl = (item: any, useLegacyAuth: boolean, size?: number) => {
   );
 };
 
-export const getDownloadUrl = (id: string, useLegacyAuth = legacyAuth) => {
+export const getDownloadUrl = (options: { id: string }, useLegacyAuth = legacyAuth) => {
   if (useLegacyAuth) {
     return (
       `${API_BASE_URL}/download` +
-      `?id=${id}` +
+      `?id=${options.id}` +
       `&u=${auth.username}` +
       `&p=${auth.password}` +
       `&v=1.15.0` +
@@ -134,7 +134,7 @@ export const getDownloadUrl = (id: string, useLegacyAuth = legacyAuth) => {
 
   return (
     `${API_BASE_URL}/download` +
-    `?id=${id}` +
+    `?id=${options.id}` +
     `&u=${auth.username}` +
     `&s=${auth.salt}` +
     `&t=${auth.hash}` +

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -424,35 +424,35 @@ export const getScanStatus = async () => {
   return scanStatus;
 };
 
-export const star = async (id: string, type: string) => {
+export const star = async (options: { id: string; type: string }) => {
   const { data } = await api.get(`/star`, {
     params: {
-      id: type === 'music' ? id : undefined,
-      albumId: type === 'album' ? id : undefined,
-      artistId: type === 'artist' ? id : undefined,
+      id: options.type === 'music' ? options.id : undefined,
+      albumId: options.type === 'album' ? options.id : undefined,
+      artistId: options.type === 'artist' ? options.id : undefined,
     },
   });
 
   return data;
 };
 
-export const unstar = async (id: string, type: string) => {
+export const unstar = async (options: { id: string; type: string }) => {
   const { data } = await api.get(`/unstar`, {
     params: {
-      id: type === 'music' ? id : undefined,
-      albumId: type === 'album' ? id : undefined,
-      artistId: type === 'artist' ? id : undefined,
+      id: options.type === 'music' ? options.id : undefined,
+      albumId: options.type === 'album' ? options.id : undefined,
+      artistId: options.type === 'artist' ? options.id : undefined,
     },
   });
 
   return data;
 };
 
-export const batchStar = async (ids: string[], type: string) => {
-  const idChunks = _.chunk(ids, 325);
+export const batchStar = async (options: { ids: string[]; type: string }) => {
+  const idChunks = _.chunk(options.ids, 325);
 
   let idParam: string;
-  switch (type) {
+  switch (options.type) {
     case 'music':
       idParam = 'id';
       break;
@@ -481,11 +481,11 @@ export const batchStar = async (ids: string[], type: string) => {
   return res;
 };
 
-export const batchUnstar = async (ids: string[], type: string) => {
-  const idChunks = _.chunk(ids, 325);
+export const batchUnstar = async (options: { ids: string[]; type: string }) => {
+  const idChunks = _.chunk(options.ids, 325);
 
   let idParam: string;
-  switch (type) {
+  switch (options.type) {
     case 'music':
       idParam = 'id';
       break;
@@ -514,21 +514,21 @@ export const batchUnstar = async (ids: string[], type: string) => {
   return res;
 };
 
-export const setRating = async (id: string, rating: number) => {
-  const { data } = await api.get(`/setRating`, { params: { id, rating } });
+export const setRating = async (options: { id: string; rating: number }) => {
+  const { data } = await api.get(`/setRating`, { params: options });
   return data;
 };
 
-export const getSimilarSongs = async (id: string, count: number) => {
-  const { data } = await api.get(`/getSimilarSongs2`, { params: { id, count } });
+export const getSimilarSongs = async (options: { id: string; count: number }) => {
+  const { data } = await api.get(`/getSimilarSongs2`, { params: options });
   return (data.similarSongs2.song || []).map((entry: any) => normalizeSong(entry));
 };
 
-export const updatePlaylistSongs = async (id: string, entry: any[]) => {
+export const updatePlaylistSongs = async (options: { id: string; entry: any[] }) => {
   const playlistParams = new URLSearchParams();
-  const songIds = _.map(entry, 'id');
+  const songIds = _.map(options.entry, 'id');
 
-  playlistParams.append('playlistId', id);
+  playlistParams.append('playlistId', options.id);
   songIds.map((songId: string) => playlistParams.append('songId', songId));
   _.mapValues(authParams, (value: string, key: string) => {
     playlistParams.append(key, value);
@@ -541,8 +541,8 @@ export const updatePlaylistSongs = async (id: string, entry: any[]) => {
   return data;
 };
 
-export const updatePlaylistSongsLg = async (playlistId: string, entry: any[]) => {
-  const entryIds = _.map(entry, 'id');
+export const updatePlaylistSongsLg = async (options: { id: string; entry: any[] }) => {
+  const entryIds = _.map(options.entry, 'id');
 
   // Set these in chunks so the api doesn't break
   // Testing on the airsonic api broke around ~350 entries
@@ -552,7 +552,7 @@ export const updatePlaylistSongsLg = async (playlistId: string, entry: any[]) =>
   for (let i = 0; i < entryIdChunks.length; i += 1) {
     const params = new URLSearchParams();
 
-    params.append('playlistId', playlistId);
+    params.append('playlistId', options.id);
     _.mapValues(authParams, (value: string, key: string) => {
       params.append(key, value);
     });
@@ -571,37 +571,40 @@ export const updatePlaylistSongsLg = async (playlistId: string, entry: any[]) =>
   return res;
 };
 
-export const deletePlaylist = async (id: string) => {
-  const { data } = await api.get(`/deletePlaylist`, { params: { id } });
+export const deletePlaylist = async (options: { id: string }) => {
+  const { data } = await api.get(`/deletePlaylist`, { params: { playlistId: options.id } });
   return data;
 };
 
-export const createPlaylist = async (name: string) => {
-  const { data } = await api.get(`/createPlaylist`, { params: { name } });
+export const createPlaylist = async (options: { name: string }) => {
+  const { data } = await api.get(`/createPlaylist`, { params: options });
   return data;
 };
 
-export const updatePlaylist = async (
-  playlistId: string,
-  name: string,
-  comment: string,
-  isPublic: boolean
-) => {
+export const updatePlaylist = async (options: {
+  id: string;
+  name: string;
+  comment: string;
+  isPublic: boolean;
+}) => {
   const { data } = await api.get(`/updatePlaylist`, {
     params: {
-      playlistId,
-      name,
-      comment,
-      public: isPublic,
+      playlistId: options.id,
+      name: options.name,
+      comment: options.comment,
+      public: options.isPublic,
     },
   });
 
   return data;
 };
 
-export const clearPlaylist = async (playlistId: string) => {
+export const clearPlaylist = async (options: { id: string }) => {
   // Specifying the playlistId without any songs will empty the existing playlist
-  const { data } = await api.get(`/createPlaylist`, { params: { playlistId, songId: '' } });
+  const { data } = await api.get(`/createPlaylist`, {
+    params: { playlistId: options.id, songId: '' },
+  });
+
   return data;
 };
 
@@ -610,7 +613,7 @@ export const getGenres = async () => {
   return (data.genres.genre || []).map((entry: any) => normalizeGenre(entry));
 };
 
-export const search3 = async (options: {
+export const getSearch = async (options: {
   query: string;
   artistCount?: number;
   artistOffset?: 0;
@@ -673,7 +676,7 @@ export const getMusicDirectory = async (options: { id: string }) => {
   };
 };
 
-export const getDirectorySongs = async (options: { id: string }, data: any[] = []) => {
+export const getMusicDirectorySongs = async (options: { id: string }, data: any[] = []) => {
   if (options.id === 'stop') {
     const songs: any[] = [];
 
@@ -693,17 +696,17 @@ export const getDirectorySongs = async (options: { id: string }, data: any[] = [
       if (res.child.filter((entry: any) => entry.isDir === true).length === 0) {
         // Add the last directory if there are no other directories
         data.push(res);
-        return getDirectorySongs({ id: 'stop' }, data);
+        return getMusicDirectorySongs({ id: 'stop' }, data);
       }
 
       data.push(res);
       const nestedFolders = res.child.filter((entry: any) => entry.isDir === true);
 
       for (let i = 0; i < nestedFolders.length; i += 1) {
-        await getDirectorySongs({ id: nestedFolders[i].id }, data);
+        await getMusicDirectorySongs({ id: nestedFolders[i].id }, data);
       }
 
-      return getDirectorySongs({ id: 'stop' }, data);
+      return getMusicDirectorySongs({ id: 'stop' }, data);
     })
     .catch((err) => console.log(err));
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -279,8 +279,8 @@ const normalizeFolder = (item: any) => {
   };
 };
 
-export const getPlaylist = async (id: string) => {
-  const { data } = await api.get(`/getPlaylist?id=${id}`);
+export const getPlaylist = async (options: { id: string }) => {
+  const { data } = await api.get(`/getPlaylist?id=${options.id}`);
   return normalizePlaylist(data.playlist);
 };
 

--- a/src/api/controller.ts
+++ b/src/api/controller.ts
@@ -11,6 +11,7 @@ import {
   getArtistInfo,
   getArtists,
   getArtistSongs,
+  getDownloadUrl,
   getGenres,
   getIndexes,
   getMusicDirectory,
@@ -23,6 +24,8 @@ import {
   getSearch,
   getSimilarSongs,
   getStarred,
+  scrobble,
+  setRating,
   star,
   startScan,
   unstar,
@@ -31,7 +34,7 @@ import {
   updatePlaylistSongsLg,
 } from './api';
 import { getPlaylist as jfGetPlaylist, getPlaylists as jfGetPlaylists } from './jellyfinApi';
-import { APIEndpoints, ServerType } from './types';
+import { APIEndpoints, ServerType } from '../types';
 
 // prettier-ignore
 const endpoints = [
@@ -51,6 +54,7 @@ const endpoints = [
   { id: 'unstar', endpoint: { subsonic: unstar, jellyfin: undefined } },
   { id: 'batchStar', endpoint: { subsonic: batchStar, jellyfin: undefined } },
   { id: 'batchUnstar', endpoint: { subsonic: batchUnstar, jellyfin: undefined } },
+  { id: 'setRating', endpoint: { subsonic: setRating, jellyfin: undefined } },
   { id: 'getSimilarSongs', endpoint: { subsonic: getSimilarSongs, jellyfin: undefined } },
   { id: 'updatePlaylistSongs', endpoint: { subsonic: updatePlaylistSongs, jellyfin: undefined } },
   { id: 'updatePlaylistSongsLg', endpoint: { subsonic: updatePlaylistSongsLg, jellyfin: undefined } },
@@ -60,10 +64,12 @@ const endpoints = [
   { id: 'clearPlaylist', endpoint: { subsonic: clearPlaylist, jellyfin: undefined } },
   { id: 'getGenres', endpoint: { subsonic: getGenres, jellyfin: undefined } },
   { id: 'getSearch', endpoint: { subsonic: getSearch, jellyfin: undefined } },
+  { id: 'scrobble', endpoint: { subsonic: scrobble, jellyfin: undefined } },
   { id: 'getIndexes', endpoint: { subsonic: getIndexes, jellyfin: undefined } },
   { id: 'getMusicFolders', endpoint: { subsonic: getMusicFolders, jellyfin: undefined } },
   { id: 'getMusicDirectory', endpoint: { subsonic: getMusicDirectory, jellyfin: undefined } },
   { id: 'getMusicDirectorySongs', endpoint: { subsonic: getMusicDirectorySongs, jellyfin: undefined } },
+  { id: 'getDownloadUrl', endpoint: { subsonic: getDownloadUrl, jellyfin: undefined } },
 ];
 
 export const apiController = async (options: {
@@ -71,14 +77,13 @@ export const apiController = async (options: {
   endpoint: APIEndpoints;
   args?: any;
 }) => {
-  const selectedEndpoint = endpoints.find((e) => e.id === options.endpoint)?.endpoint[
-    options.serverType
-  ];
+  const selectedEndpoint = endpoints.find((e) => e.id === options.endpoint);
+  const selectedEndpointFn = selectedEndpoint!.endpoint[options.serverType];
 
-  if (!selectedEndpoint) {
+  if (!selectedEndpointFn || !selectedEndpoint) {
     return notifyToast('warning', `[${options.endpoint}] not available`);
   }
 
-  const res = await selectedEndpoint(options.args);
+  const res = await selectedEndpointFn(options.args);
   return res;
 };

--- a/src/api/controller.ts
+++ b/src/api/controller.ts
@@ -30,12 +30,12 @@ import {
   updatePlaylistSongs,
   updatePlaylistSongsLg,
 } from './api';
-import { getPlaylists as jfGetPlaylists } from './jellyfinApi';
+import { getPlaylist as jfGetPlaylist, getPlaylists as jfGetPlaylists } from './jellyfinApi';
 import { APIEndpoints, ServerType } from './types';
 
 // prettier-ignore
 const endpoints = [
-  { id: 'getPlaylist', endpoint: { subsonic: getPlaylist, jellyfin: undefined } },
+  { id: 'getPlaylist', endpoint: { subsonic: getPlaylist, jellyfin: jfGetPlaylist } },
   { id: 'getPlaylists', endpoint: { subsonic: getPlaylists, jellyfin: jfGetPlaylists } },
   { id: 'getStarred', endpoint: { subsonic: getStarred, jellyfin: undefined } },
   { id: 'getAlbum', endpoint: { subsonic: getAlbum, jellyfin: undefined } },

--- a/src/api/controller.ts
+++ b/src/api/controller.ts
@@ -1,0 +1,19 @@
+import { notifyToast } from '../components/shared/toast';
+import { getPlaylists } from './api';
+import { getPlaylists as jfGetPlaylists } from './jellyfinApi';
+import { APIEndpoints, ServerType } from './types';
+
+const endpoints = [
+  { id: 'getPlaylist', endpoint: { subsonic: undefined, jellyfin: undefined } },
+  { id: 'getPlaylists', endpoint: { subsonic: getPlaylists, jellyfin: jfGetPlaylists } },
+];
+
+export const apiController = async (serverType: ServerType, endpoint: APIEndpoints) => {
+  const selectedEndpoint = endpoints.find((e) => e.id === endpoint)?.endpoint[serverType];
+
+  if (!selectedEndpoint) {
+    return notifyToast('warning', `[${endpoint}] not available`);
+  }
+
+  return selectedEndpoint();
+};

--- a/src/api/controller.ts
+++ b/src/api/controller.ts
@@ -1,19 +1,84 @@
 import { notifyToast } from '../components/shared/toast';
-import { getPlaylists } from './api';
+import {
+  batchStar,
+  batchUnstar,
+  clearPlaylist,
+  createPlaylist,
+  deletePlaylist,
+  getAlbum,
+  getAlbums,
+  getArtist,
+  getArtistInfo,
+  getArtists,
+  getArtistSongs,
+  getGenres,
+  getIndexes,
+  getMusicDirectory,
+  getMusicDirectorySongs,
+  getMusicFolders,
+  getPlaylist,
+  getPlaylists,
+  getRandomSongs,
+  getScanStatus,
+  getSearch,
+  getSimilarSongs,
+  getStarred,
+  star,
+  startScan,
+  unstar,
+  updatePlaylist,
+  updatePlaylistSongs,
+  updatePlaylistSongsLg,
+} from './api';
 import { getPlaylists as jfGetPlaylists } from './jellyfinApi';
 import { APIEndpoints, ServerType } from './types';
 
+// prettier-ignore
 const endpoints = [
-  { id: 'getPlaylist', endpoint: { subsonic: undefined, jellyfin: undefined } },
+  { id: 'getPlaylist', endpoint: { subsonic: getPlaylist, jellyfin: undefined } },
   { id: 'getPlaylists', endpoint: { subsonic: getPlaylists, jellyfin: jfGetPlaylists } },
+  { id: 'getStarred', endpoint: { subsonic: getStarred, jellyfin: undefined } },
+  { id: 'getAlbum', endpoint: { subsonic: getAlbum, jellyfin: undefined } },
+  { id: 'getAlbums', endpoint: { subsonic: getAlbums, jellyfin: undefined } },
+  { id: 'getRandomSongs', endpoint: { subsonic: getRandomSongs, jellyfin: undefined } },
+  { id: 'getArtist', endpoint: { subsonic: getArtist, jellyfin: undefined } },
+  { id: 'getArtists', endpoint: { subsonic: getArtists, jellyfin: undefined } },
+  { id: 'getArtistInfo', endpoint: { subsonic: getArtistInfo, jellyfin: undefined } },
+  { id: 'getArtistSongs', endpoint: { subsonic: getArtistSongs, jellyfin: undefined } },
+  { id: 'startScan', endpoint: { subsonic: startScan, jellyfin: undefined } },
+  { id: 'getScanStatus', endpoint: { subsonic: getScanStatus, jellyfin: undefined } },
+  { id: 'star', endpoint: { subsonic: star, jellyfin: undefined } },
+  { id: 'unstar', endpoint: { subsonic: unstar, jellyfin: undefined } },
+  { id: 'batchStar', endpoint: { subsonic: batchStar, jellyfin: undefined } },
+  { id: 'batchUnstar', endpoint: { subsonic: batchUnstar, jellyfin: undefined } },
+  { id: 'getSimilarSongs', endpoint: { subsonic: getSimilarSongs, jellyfin: undefined } },
+  { id: 'updatePlaylistSongs', endpoint: { subsonic: updatePlaylistSongs, jellyfin: undefined } },
+  { id: 'updatePlaylistSongsLg', endpoint: { subsonic: updatePlaylistSongsLg, jellyfin: undefined } },
+  { id: 'deletePlaylist', endpoint: { subsonic: deletePlaylist, jellyfin: undefined } },
+  { id: 'createPlaylist', endpoint: { subsonic: createPlaylist, jellyfin: undefined } },
+  { id: 'updatePlaylist', endpoint: { subsonic: updatePlaylist, jellyfin: undefined } },
+  { id: 'clearPlaylist', endpoint: { subsonic: clearPlaylist, jellyfin: undefined } },
+  { id: 'getGenres', endpoint: { subsonic: getGenres, jellyfin: undefined } },
+  { id: 'getSearch', endpoint: { subsonic: getSearch, jellyfin: undefined } },
+  { id: 'getIndexes', endpoint: { subsonic: getIndexes, jellyfin: undefined } },
+  { id: 'getMusicFolders', endpoint: { subsonic: getMusicFolders, jellyfin: undefined } },
+  { id: 'getMusicDirectory', endpoint: { subsonic: getMusicDirectory, jellyfin: undefined } },
+  { id: 'getMusicDirectorySongs', endpoint: { subsonic: getMusicDirectorySongs, jellyfin: undefined } },
 ];
 
-export const apiController = async (serverType: ServerType, endpoint: APIEndpoints) => {
-  const selectedEndpoint = endpoints.find((e) => e.id === endpoint)?.endpoint[serverType];
+export const apiController = async (options: {
+  serverType: ServerType;
+  endpoint: APIEndpoints;
+  args?: any;
+}) => {
+  const selectedEndpoint = endpoints.find((e) => e.id === options.endpoint)?.endpoint[
+    options.serverType
+  ];
 
   if (!selectedEndpoint) {
-    return notifyToast('warning', `[${endpoint}] not available`);
+    return notifyToast('warning', `[${options.endpoint}] not available`);
   }
 
-  return selectedEndpoint();
+  const res = await selectedEndpoint(options.args);
+  return res;
 };

--- a/src/api/jellyfinApi.ts
+++ b/src/api/jellyfinApi.ts
@@ -1,0 +1,62 @@
+import axios from 'axios';
+import _ from 'lodash';
+import { handleDisconnect } from '../components/settings/DisconnectButton';
+import { notifyToast } from '../components/shared/toast';
+
+const getAuth = () => {
+  return {
+    userId: localStorage.getItem('username') || '',
+    token: localStorage.getItem('token') || '',
+    server: localStorage.getItem('server') || '',
+    deviceId: localStorage.getItem('deviceId') || '',
+  };
+};
+
+const auth = getAuth();
+const API_BASE_URL = `${auth.server}`;
+
+export const jellyfinApi = axios.create({
+  baseURL: API_BASE_URL,
+});
+
+jellyfinApi.interceptors.request.use(
+  (config) => {
+    const { token } = auth;
+
+    config.headers.common['X-MediaBrowser-Token'] = token;
+    // config.headers[
+    //   'X-Emby-Authorization'
+    // ] = `MediaBrowser Client="Sonixd", Device="PC", DeviceId="${deviceId}", Version="N/a"`;
+
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+jellyfinApi.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    if (err.response && err.response.status === 401) {
+      notifyToast('warning', 'Session expired. Logging out.');
+      handleDisconnect();
+    }
+
+    return Promise.reject(err);
+  }
+);
+
+export const getPlaylists = async () => {
+  const params = {
+    SortBy: 'SortName',
+    SortOrder: 'Ascending',
+    IncludeItemTypes: 'Playlist',
+    Recursive: true,
+  };
+
+  const playlists: any = await jellyfinApi.get(`Users/${auth.userId}/Items`, { params });
+  console.log(`playlists`, playlists);
+
+  return _.filter(playlists.Items, (item) => item.MediaType === 'Audio');
+};

--- a/src/api/jellyfinApi.ts
+++ b/src/api/jellyfinApi.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { nanoid } from 'nanoid/non-secure';
 import { handleDisconnect } from '../components/settings/DisconnectButton';
 import { notifyToast } from '../components/shared/toast';
-import { Item } from './types';
+import { Item } from '../types';
 
 const getAuth = () => {
   return {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -3,6 +3,112 @@ export enum Server {
   Jellyfin = 'jellyfin',
 }
 
-export type ServerType = Server.Subsonic | Server.Jellyfin;
+export enum Item {
+  Album = 'album',
+  Artist = 'artist',
+  Folder = 'folder',
+  Genre = 'genre',
+  Music = 'music',
+  Playlist = 'playlist',
+}
 
+export type ServerType = Server.Subsonic | Server.Jellyfin;
 export type APIEndpoints = 'getPlaylist' | 'getPlaylists';
+
+export interface Album {
+  id: string;
+  title: string;
+  isDir?: boolean;
+  albumId: string;
+  artist?: string;
+  artistId?: string;
+  songCount: number;
+  duration: number;
+  created: string;
+  year?: number;
+  genre?: string;
+  image: string;
+  starred?: string;
+  type: Item.Album;
+  uniqueId: string;
+  song?: Song[];
+}
+
+export interface Artist {
+  id: string;
+  title: string;
+  albumCount: number;
+  image: string;
+  starred?: string;
+  type: Item.Artist;
+  uniqueId: string;
+  album: Album[];
+}
+
+export interface ArtistInfo {
+  biography?: string;
+  lastFmUrl?: string;
+  imageUrl?: string;
+  similarArtist?: Artist[];
+}
+export interface Folder {
+  id: string;
+  title: string;
+  isDir?: boolean;
+  image: string;
+  type: Item.Folder;
+  uniqueId: string;
+}
+
+export interface Genre {
+  id: string;
+  title: string;
+  songCount?: number;
+  albumCount?: number;
+  type: Item.Genre;
+  uniqueId: string;
+}
+
+export interface Playlist {
+  id: string;
+  title: string;
+  comment?: string;
+  owner: string;
+  public?: boolean;
+  songCount: number;
+  duration: number;
+  created: string;
+  changed: string;
+  image: string;
+  type: Item.Playlist;
+  uniqueId: string;
+  song?: Song[];
+}
+
+export interface Song {
+  id: string;
+  parent?: string;
+  title: string;
+  isDir?: boolean;
+  album: string;
+  albumId?: string;
+  artist: string;
+  artistId?: string;
+  track?: number;
+  year?: number;
+  genre?: string;
+  size: number;
+  contentType?: string;
+  suffix?: string;
+  duration?: number;
+  bitRate?: number;
+  path?: string;
+  playCount?: number;
+  discNumber?: number;
+  created: string;
+  streamUrl: string;
+  image: string;
+  starred?: string;
+  type: Item.Music;
+  uniqueId: string;
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,8 @@
+export enum Server {
+  Subsonic = 'subsonic',
+  Jellyfin = 'jellyfin',
+}
+
+export type ServerType = Server.Subsonic | Server.Jellyfin;
+
+export type APIEndpoints = 'getPlaylist' | 'getPlaylists';

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -73,12 +73,12 @@ export interface Playlist {
   id: string;
   title: string;
   comment?: string;
-  owner: string;
+  owner?: string;
   public?: boolean;
-  songCount: number;
+  songCount?: number;
   duration: number;
-  created: string;
-  changed: string;
+  created?: string;
+  changed?: string;
   image: string;
   type: Item.Playlist;
   uniqueId: string;

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Icon } from 'rsuite';
 import { useHistory } from 'react-router-dom';
 import cacheImage from '../shared/cacheImage';
-import { getAlbum, getPlaylist, getAllArtistSongs } from '../../api/api';
+import { getAlbum, getPlaylist, getArtistSongs } from '../../api/api';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import {
   appendPlayQueue,
@@ -76,7 +76,7 @@ const Card = ({
     }
 
     if (playClick.type === 'album') {
-      const res = await getAlbum(playClick.id);
+      const res = await getAlbum({ id: playClick.id });
       const songs = filterPlayQueue(config.playback.filters, res.song);
 
       if (songs.entries.length > 0) {
@@ -92,7 +92,7 @@ const Card = ({
     }
 
     if (playClick.type === 'artist') {
-      const res = await getAllArtistSongs(playClick.id);
+      const res = await getArtistSongs({ id: playClick.id });
       const songs = filterPlayQueue(config.playback.filters, res);
 
       if (songs.entries.length > 0) {
@@ -122,7 +122,7 @@ const Card = ({
     }
 
     if (playClick.type === 'album') {
-      const res = await getAlbum(playClick.id);
+      const res = await getAlbum({ id: playClick.id });
       const songs = filterPlayQueue(config.playback.filters, res.song);
 
       if (songs.entries.length > 0) {
@@ -134,7 +134,7 @@ const Card = ({
     }
 
     if (playClick.type === 'artist') {
-      const res = await getAllArtistSongs(playClick.id);
+      const res = await getArtistSongs({ id: playClick.id });
       const songs = filterPlayQueue(config.playback.filters, res);
 
       if (songs.entries.length > 0) {

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Icon } from 'rsuite';
 import { useHistory } from 'react-router-dom';
 import cacheImage from '../shared/cacheImage';
-import { getAlbum, getPlaylist, getArtistSongs } from '../../api/api';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import {
   appendPlayQueue,
@@ -32,6 +31,7 @@ import { setStatus } from '../../redux/playerSlice';
 import { addModalPage } from '../../redux/miscSlice';
 import { notifyToast } from '../shared/toast';
 import CustomTooltip from '../shared/CustomTooltip';
+import { apiController } from '../../api/controller';
 
 const Card = ({
   onClick,
@@ -60,7 +60,12 @@ const Card = ({
 
   const handlePlayClick = async () => {
     if (playClick.type === 'playlist') {
-      const res = await getPlaylist(playClick.id);
+      const res = await apiController({
+        serverType: config.serverType,
+        endpoint: 'getPlaylist',
+        args: { id: playClick.id },
+      });
+
       const songs = filterPlayQueue(config.playback.filters, res.song);
 
       if (songs.entries.length > 0) {
@@ -76,7 +81,12 @@ const Card = ({
     }
 
     if (playClick.type === 'album') {
-      const res = await getAlbum({ id: playClick.id });
+      const res = await apiController({
+        serverType: config.serverType,
+        endpoint: 'getAlbum',
+        args: { id: playClick.id },
+      });
+
       const songs = filterPlayQueue(config.playback.filters, res.song);
 
       if (songs.entries.length > 0) {
@@ -92,7 +102,12 @@ const Card = ({
     }
 
     if (playClick.type === 'artist') {
-      const res = await getArtistSongs({ id: playClick.id });
+      const res = await apiController({
+        serverType: config.serverType,
+        endpoint: 'getArtistSongs',
+        args: { id: playClick.id },
+      });
+
       const songs = filterPlayQueue(config.playback.filters, res);
 
       if (songs.entries.length > 0) {
@@ -110,7 +125,12 @@ const Card = ({
 
   const handlePlayAppend = async (type: 'next' | 'later') => {
     if (playClick.type === 'playlist') {
-      const res = await getPlaylist(playClick.id);
+      const res = await apiController({
+        serverType: config.serverType,
+        endpoint: 'getPlaylist',
+        args: { id: playClick.id },
+      });
+
       const songs = filterPlayQueue(config.playback.filters, res.song);
 
       if (songs.entries.length > 0) {
@@ -122,7 +142,12 @@ const Card = ({
     }
 
     if (playClick.type === 'album') {
-      const res = await getAlbum({ id: playClick.id });
+      const res = await apiController({
+        serverType: config.serverType,
+        endpoint: 'getAlbum',
+        args: { id: playClick.id },
+      });
+
       const songs = filterPlayQueue(config.playback.filters, res.song);
 
       if (songs.entries.length > 0) {
@@ -134,7 +159,12 @@ const Card = ({
     }
 
     if (playClick.type === 'artist') {
-      const res = await getArtistSongs({ id: playClick.id });
+      const res = await apiController({
+        serverType: config.serverType,
+        endpoint: 'getArtistSongs',
+        args: { id: playClick.id },
+      });
+
       const songs = filterPlayQueue(config.playback.filters, res);
 
       if (songs.entries.length > 0) {

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -48,7 +48,7 @@ const Dashboard = () => {
 
   const handleFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star(rowData.id, 'album');
+      await star({ id: rowData.id, type: 'album' });
       dispatch(setStar({ id: [rowData.id], type: 'star' }));
       queryClient.setQueryData(['recentAlbums', musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
@@ -83,7 +83,7 @@ const Dashboard = () => {
         return oldData;
       });
     } else {
-      await unstar(rowData.id, 'album');
+      await unstar({ id: rowData.id, type: 'album' });
       dispatch(setStar({ id: [rowData.id], type: 'unstar' }));
       queryClient.setQueryData(['recentAlbums', musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -28,22 +28,22 @@ const Dashboard = () => {
 
   const { isLoading: isLoadingRecent, data: recentAlbums }: any = useQuery(
     ['recentAlbums', musicFolder],
-    () => getAlbums({ type: 'recent', size: 20, musicFolderId: musicFolder })
+    () => getAlbums({ type: 'recent', size: 20, offset: 0, musicFolderId: musicFolder })
   );
 
   const { isLoading: isLoadingNewest, data: newestAlbums }: any = useQuery(
     ['newestAlbums', musicFolder],
-    () => getAlbums({ type: 'newest', size: 20, musicFolderId: musicFolder })
+    () => getAlbums({ type: 'newest', size: 20, offset: 0, musicFolderId: musicFolder })
   );
 
   const { isLoading: isLoadingRandom, data: randomAlbums }: any = useQuery(
     ['randomAlbums', musicFolder],
-    () => getAlbums({ type: 'random', size: 20, musicFolderId: musicFolder })
+    () => getAlbums({ type: 'random', size: 20, offset: 0, musicFolderId: musicFolder })
   );
 
   const { isLoading: isLoadingFrequent, data: frequentAlbums }: any = useQuery(
     ['frequentAlbums', musicFolder],
-    () => getAlbums({ type: 'frequent', size: 20, musicFolderId: musicFolder })
+    () => getAlbums({ type: 'frequent', size: 20, offset: 0, musicFolderId: musicFolder })
   );
 
   const handleFavorite = async (rowData: any) => {
@@ -51,33 +51,33 @@ const Dashboard = () => {
       await star(rowData.id, 'album');
       dispatch(setStar({ id: [rowData.id], type: 'star' }));
       queryClient.setQueryData(['recentAlbums', musicFolder], (oldData: any) => {
-        const starredIndices = _.keys(_.pickBy(oldData?.album, { id: rowData.id }));
+        const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {
-          oldData.album[index].starred = Date.now();
+          oldData[index].starred = Date.now();
         });
 
         return oldData;
       });
       queryClient.setQueryData(['newestAlbums', musicFolder], (oldData: any) => {
-        const starredIndices = _.keys(_.pickBy(oldData?.album, { id: rowData.id }));
+        const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {
-          oldData.album[index].starred = Date.now();
+          oldData[index].starred = Date.now();
         });
 
         return oldData;
       });
       queryClient.setQueryData(['randomAlbums', musicFolder], (oldData: any) => {
-        const starredIndices = _.keys(_.pickBy(oldData?.album, { id: rowData.id }));
+        const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {
-          oldData.album[index].starred = Date.now();
+          oldData[index].starred = Date.now();
         });
 
         return oldData;
       });
       queryClient.setQueryData(['frequentAlbums', musicFolder], (oldData: any) => {
-        const starredIndices = _.keys(_.pickBy(oldData?.album, { id: rowData.id }));
+        const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {
-          oldData.album[index].starred = Date.now();
+          oldData[index].starred = Date.now();
         });
 
         return oldData;
@@ -86,33 +86,33 @@ const Dashboard = () => {
       await unstar(rowData.id, 'album');
       dispatch(setStar({ id: [rowData.id], type: 'unstar' }));
       queryClient.setQueryData(['recentAlbums', musicFolder], (oldData: any) => {
-        const starredIndices = _.keys(_.pickBy(oldData?.album, { id: rowData.id }));
+        const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {
-          oldData.album[index].starred = undefined;
+          oldData[index].starred = undefined;
         });
 
         return oldData;
       });
       queryClient.setQueryData(['newestAlbums', musicFolder], (oldData: any) => {
-        const starredIndices = _.keys(_.pickBy(oldData?.album, { id: rowData.id }));
+        const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {
-          oldData.album[index].starred = undefined;
+          oldData[index].starred = undefined;
         });
 
         return oldData;
       });
       queryClient.setQueryData(['randomAlbums', musicFolder], (oldData: any) => {
-        const starredIndices = _.keys(_.pickBy(oldData?.album, { id: rowData.id }));
+        const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {
-          oldData.album[index].starred = undefined;
+          oldData[index].starred = undefined;
         });
 
         return oldData;
       });
       queryClient.setQueryData(['frequentAlbums', musicFolder], (oldData: any) => {
-        const starredIndices = _.keys(_.pickBy(oldData?.album, { id: rowData.id }));
+        const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {
-          oldData.album[index].starred = undefined;
+          oldData[index].starred = undefined;
         });
 
         return oldData;
@@ -134,10 +134,10 @@ const Dashboard = () => {
         <>
           <ScrollingMenu
             title="Recently Played"
-            data={recentAlbums.album}
+            data={recentAlbums}
             cardTitle={{
               prefix: '/library/album',
-              property: 'name',
+              property: 'title',
               urlProperty: 'albumId',
             }}
             cardSubtitle={{
@@ -158,10 +158,10 @@ const Dashboard = () => {
 
           <ScrollingMenu
             title="Recently Added"
-            data={newestAlbums.album}
+            data={newestAlbums}
             cardTitle={{
               prefix: '/library/album',
-              property: 'name',
+              property: 'title',
               urlProperty: 'albumId',
             }}
             cardSubtitle={{
@@ -182,10 +182,10 @@ const Dashboard = () => {
 
           <ScrollingMenu
             title="Random"
-            data={randomAlbums.album}
+            data={randomAlbums}
             cardTitle={{
               prefix: '/library/album',
-              property: 'name',
+              property: 'title',
               urlProperty: 'albumId',
             }}
             cardSubtitle={{
@@ -206,10 +206,10 @@ const Dashboard = () => {
 
           <ScrollingMenu
             title="Most Played"
-            data={frequentAlbums.album}
+            data={frequentAlbums}
             cardTitle={{
               prefix: '/library/album',
-              property: 'name',
+              property: 'title',
               urlProperty: 'albumId',
             }}
             cardSubtitle={{

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import _ from 'lodash';
 import { useHistory } from 'react-router-dom';
 import { useQuery, useQueryClient } from 'react-query';
-import { getAlbums, star, unstar } from '../../api/api';
 import PageLoader from '../loader/PageLoader';
 import GenericPage from '../layout/GenericPage';
 import GenericPageHeader from '../layout/GenericPageHeader';
@@ -10,6 +9,8 @@ import ScrollingMenu from '../scrollingmenu/ScrollingMenu';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { setStar } from '../../redux/playQueueSlice';
 import { setActive } from '../../redux/albumSlice';
+import { apiController } from '../../api/controller';
+import { Server } from '../../types';
 
 const Dashboard = () => {
   const history = useHistory();
@@ -28,27 +29,63 @@ const Dashboard = () => {
 
   const { isLoading: isLoadingRecent, data: recentAlbums }: any = useQuery(
     ['recentAlbums', musicFolder],
-    () => getAlbums({ type: 'recent', size: 20, offset: 0, musicFolderId: musicFolder })
+    () =>
+      apiController({
+        serverType: config.serverType,
+        endpoint: 'getAlbums',
+        args:
+          config.serverType === Server.Subsonic
+            ? { type: 'recent', size: 20, offset: 0, musicFolderId: musicFolder }
+            : null,
+      })
   );
 
   const { isLoading: isLoadingNewest, data: newestAlbums }: any = useQuery(
     ['newestAlbums', musicFolder],
-    () => getAlbums({ type: 'newest', size: 20, offset: 0, musicFolderId: musicFolder })
+    () =>
+      apiController({
+        serverType: config.serverType,
+        endpoint: 'getAlbums',
+        args:
+          config.serverType === Server.Subsonic
+            ? { type: 'newest', size: 20, offset: 0, musicFolderId: musicFolder }
+            : null,
+      })
   );
 
   const { isLoading: isLoadingRandom, data: randomAlbums }: any = useQuery(
     ['randomAlbums', musicFolder],
-    () => getAlbums({ type: 'random', size: 20, offset: 0, musicFolderId: musicFolder })
+    () =>
+      apiController({
+        serverType: config.serverType,
+        endpoint: 'getAlbums',
+        args:
+          config.serverType === Server.Subsonic
+            ? { type: 'random', size: 20, offset: 0, musicFolderId: musicFolder }
+            : null,
+      })
   );
 
   const { isLoading: isLoadingFrequent, data: frequentAlbums }: any = useQuery(
     ['frequentAlbums', musicFolder],
-    () => getAlbums({ type: 'frequent', size: 20, offset: 0, musicFolderId: musicFolder })
+    () =>
+      apiController({
+        serverType: config.serverType,
+        endpoint: 'getAlbums',
+        args:
+          config.serverType === Server.Subsonic
+            ? { type: 'frequent', size: 20, offset: 0, musicFolderId: musicFolder }
+            : null,
+      })
   );
 
   const handleFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star({ id: rowData.id, type: 'album' });
+      await apiController({
+        serverType: config.serverType,
+        endpoint: 'star',
+        args: config.serverType === Server.Subsonic ? { id: rowData.id, type: 'album' } : null,
+      });
       dispatch(setStar({ id: [rowData.id], type: 'star' }));
       queryClient.setQueryData(['recentAlbums', musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
@@ -83,7 +120,11 @@ const Dashboard = () => {
         return oldData;
       });
     } else {
-      await unstar({ id: rowData.id, type: 'album' });
+      await apiController({
+        serverType: config.serverType,
+        endpoint: 'unstar',
+        args: config.serverType === Server.Subsonic ? { id: rowData.id, type: 'album' } : null,
+      });
       dispatch(setStar({ id: [rowData.id], type: 'unstar' }));
       queryClient.setQueryData(['recentAlbums', musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));

--- a/src/components/library/AlbumList.tsx
+++ b/src/components/library/AlbumList.tsx
@@ -9,7 +9,7 @@ import ListViewType from '../viewtypes/ListViewType';
 import useSearchQuery from '../../hooks/useSearchQuery';
 import GenericPageHeader from '../layout/GenericPageHeader';
 import GenericPage from '../layout/GenericPage';
-import { getAlbumsDirect, getAllAlbums, getGenres, star, unstar } from '../../api/api';
+import { getAlbums, getGenres, star, unstar } from '../../api/api';
 import PageLoader from '../loader/PageLoader';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import {
@@ -56,16 +56,18 @@ const AlbumList = () => {
     ['albumList', album.active.filter, musicFolder],
     () =>
       album.active.filter === 'random'
-        ? getAlbumsDirect({
+        ? getAlbums({
             type: 'random',
             size: config.lookAndFeel.gridView.cardSize,
+            offset: 0,
             musicFolderId: musicFolder,
           })
-        : getAllAlbums({
+        : getAlbums({
             type: album.active.filter,
             size: 500,
             offset: 0,
             musicFolderId: musicFolder,
+            recursive: true,
           }),
     {
       cacheTime: 3600000, // Stay in cache for 1 hour
@@ -77,8 +79,8 @@ const AlbumList = () => {
     return res.map((genre: any) => {
       if (genre.albumCount !== 0) {
         return {
-          label: `${genre.value} (${genre.albumCount})`,
-          value: genre.value,
+          label: `${genre.title} (${genre.albumCount})`,
+          value: genre.title,
           role: 'Genre',
         };
       }
@@ -86,7 +88,7 @@ const AlbumList = () => {
     });
   });
   const filteredData = useSearchQuery(misc.searchQuery, albums, [
-    'name',
+    'title',
     'artist',
     'genre',
     'year',
@@ -228,7 +230,7 @@ const AlbumList = () => {
           data={misc.searchQuery !== '' ? filteredData : albums}
           cardTitle={{
             prefix: '/library/album',
-            property: 'name',
+            property: 'title',
             urlProperty: 'albumId',
           }}
           cardSubtitle={{

--- a/src/components/library/AlbumList.tsx
+++ b/src/components/library/AlbumList.tsx
@@ -130,7 +130,7 @@ const AlbumList = () => {
 
   const handleRowFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star(rowData.id, 'album');
+      await star({ id: rowData.id, type: 'album' });
       queryClient.setQueryData(['albumList', album.active.filter, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -140,7 +140,7 @@ const AlbumList = () => {
         return oldData;
       });
     } else {
-      await unstar(rowData.id, 'album');
+      await unstar({ id: rowData.id, type: 'album' });
       queryClient.setQueryData(['albumList', album.active.filter, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {

--- a/src/components/library/AlbumView.tsx
+++ b/src/components/library/AlbumView.tsx
@@ -68,7 +68,7 @@ const AlbumView = ({ ...rest }: any) => {
   const albumId = rest.id ? rest.id : id;
 
   const { isLoading, isError, data, error }: any = useQuery(['album', albumId], () =>
-    getAlbum(albumId)
+    getAlbum({ id: albumId })
   );
   const filteredData = useSearchQuery(misc.searchQuery, data?.song, [
     'title',
@@ -240,7 +240,7 @@ const AlbumView = ({ ...rest }: any) => {
               id: data.albumId,
             }}
             imageHeight={200}
-            title={data.name}
+            title={data.title}
             showTitleTooltip
             subtitle={
               <div>

--- a/src/components/library/AlbumView.tsx
+++ b/src/components/library/AlbumView.tsx
@@ -141,17 +141,17 @@ const AlbumView = ({ ...rest }: any) => {
 
   const handleFavorite = async () => {
     if (!data.starred) {
-      await star(data.id, 'album');
+      await star({ id: data.id, type: 'album' });
       queryClient.setQueryData(['album', id], { ...data, starred: Date.now() });
     } else {
-      await unstar(data.id, 'album');
+      await unstar({ id: data.id, type: 'album' });
       queryClient.setQueryData(['album', id], { ...data, starred: undefined });
     }
   };
 
   const handleRowFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star(rowData.id, 'music');
+      await star({ id: rowData.id, type: 'music' });
       dispatch(setStar({ id: [rowData.id], type: 'star' }));
       queryClient.setQueryData(['album', id], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData?.song, { id: rowData.id }));
@@ -162,7 +162,7 @@ const AlbumView = ({ ...rest }: any) => {
         return oldData;
       });
     } else {
-      await unstar(rowData.id, 'music');
+      await unstar({ id: rowData.id, type: 'music' });
       dispatch(setStar({ id: [rowData.id], type: 'unstar' }));
       queryClient.setQueryData(['album', id], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData?.song, { id: rowData.id }));

--- a/src/components/library/ArtistList.tsx
+++ b/src/components/library/ArtistList.tsx
@@ -79,7 +79,7 @@ const ArtistList = () => {
 
   const handleRowFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star(rowData.id, 'artist');
+      await star({ id: rowData.id, type: 'artist' });
       queryClient.setQueryData(['artistList', musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -89,7 +89,7 @@ const ArtistList = () => {
         return oldData;
       });
     } else {
-      await unstar(rowData.id, 'artist');
+      await unstar({ id: rowData.id, type: 'artist' });
       queryClient.setQueryData(['artistList', musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {

--- a/src/components/library/ArtistList.tsx
+++ b/src/components/library/ArtistList.tsx
@@ -45,7 +45,7 @@ const ArtistList = () => {
       staleTime: Infinity, // Only allow manual refresh
     }
   );
-  const filteredData = useSearchQuery(misc.searchQuery, artists, ['name']);
+  const filteredData = useSearchQuery(misc.searchQuery, artists, ['title']);
 
   let timeout: any = null;
   const handleRowClick = (e: any, rowData: any, tableData: any) => {
@@ -151,7 +151,7 @@ const ArtistList = () => {
           data={misc.searchQuery !== '' ? filteredData : artists}
           cardTitle={{
             prefix: '/library/artist',
-            property: 'name',
+            property: 'title',
             urlProperty: 'id',
           }}
           cardSubtitle={{

--- a/src/components/library/ArtistList.tsx
+++ b/src/components/library/ArtistList.tsx
@@ -4,7 +4,6 @@ import settings from 'electron-settings';
 import { useQuery, useQueryClient } from 'react-query';
 import { useHistory } from 'react-router';
 import { ButtonToolbar } from 'rsuite';
-import { getArtists, star, unstar } from '../../api/api';
 import useSearchQuery from '../../hooks/useSearchQuery';
 import GenericPage from '../layout/GenericPage';
 import GenericPageHeader from '../layout/GenericPageHeader';
@@ -19,6 +18,8 @@ import {
 } from '../../redux/multiSelectSlice';
 import GridViewType from '../viewtypes/GridViewType';
 import { RefreshButton } from '../shared/ToolbarButtons';
+import { apiController } from '../../api/controller';
+import { Server } from '../../types';
 
 const ArtistList = () => {
   const dispatch = useAppDispatch();
@@ -39,7 +40,12 @@ const ArtistList = () => {
 
   const { isLoading, isError, data: artists, error }: any = useQuery(
     ['artistList', musicFolder],
-    () => getArtists({ musicFolderId: musicFolder }),
+    () =>
+      apiController({
+        serverType: config.serverType,
+        endpoint: 'getArtists',
+        args: config.serverType === Server.Subsonic ? { musicFolderId: musicFolder } : null,
+      }),
     {
       cacheTime: 3600000, // Stay in cache for 1 hour
       staleTime: Infinity, // Only allow manual refresh
@@ -79,7 +85,11 @@ const ArtistList = () => {
 
   const handleRowFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star({ id: rowData.id, type: 'artist' });
+      await apiController({
+        serverType: config.serverType,
+        endpoint: 'star',
+        args: config.serverType === Server.Subsonic ? { id: rowData.id, type: 'artist' } : null,
+      });
       queryClient.setQueryData(['artistList', musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -89,7 +99,11 @@ const ArtistList = () => {
         return oldData;
       });
     } else {
-      await unstar({ id: rowData.id, type: 'artist' });
+      await apiController({
+        serverType: config.serverType,
+        endpoint: 'unstar',
+        args: config.serverType === Server.Subsonic ? { id: rowData.id, type: 'artist' } : null,
+      });
       queryClient.setQueryData(['artistList', musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData, { id: rowData.id }));
         starredIndices.forEach((index) => {

--- a/src/components/library/ArtistView.tsx
+++ b/src/components/library/ArtistView.tsx
@@ -16,7 +16,7 @@ import {
 } from '../shared/ToolbarButtons';
 import {
   getAlbum,
-  getAllArtistSongs,
+  getArtistSongs,
   getArtist,
   getArtistInfo,
   getDownloadUrl,
@@ -75,17 +75,17 @@ const ArtistView = ({ ...rest }: any) => {
   const { id } = useParams<ArtistParams>();
   const artistId = rest.id ? rest.id : id;
   const { isLoading, isError, data, error }: any = useQuery(['artist', artistId], () =>
-    getArtist(artistId)
+    getArtist({ id: artistId })
   );
   const {
     isLoading: isLoadingAI,
     isError: isErrorAI,
     data: artistInfo,
     error: errorAI,
-  }: any = useQuery(['artistInfo', artistId], () => getArtistInfo(artistId, 8));
+  }: any = useQuery(['artistInfo', artistId], () => getArtistInfo({ id: artistId, count: 8 }));
 
   const filteredData = useSearchQuery(misc.searchQuery, data?.album, [
-    'name',
+    'title',
     'artist',
     'genre',
     'year',
@@ -125,7 +125,7 @@ const ArtistView = ({ ...rest }: any) => {
   };
 
   const handlePlay = async () => {
-    const res = await getAllArtistSongs(data.id);
+    const res = await getArtistSongs({ id: data.id });
     const songs = filterPlayQueue(config.playback.filters, res);
 
     if (songs.entries.length > 0) {
@@ -141,7 +141,7 @@ const ArtistView = ({ ...rest }: any) => {
   };
 
   const handlePlayAppend = async (type: 'next' | 'later') => {
-    const res = await getAllArtistSongs(data.id);
+    const res = await getArtistSongs({ id: data.id });
     const songs = filterPlayQueue(config.playback.filters, res);
 
     if (songs.entries.length > 0) {
@@ -189,11 +189,11 @@ const ArtistView = ({ ...rest }: any) => {
 
       for (let i = 0; i < data.album.length; i += 1) {
         // eslint-disable-next-line no-await-in-loop
-        const albumRes = await getAlbum(data.album[i].id);
+        const albumRes = await getAlbum({ id: data.album[i].id });
         if (albumRes.song[0]?.parent) {
           downloadUrls.push(getDownloadUrl(albumRes.song[0].parent));
         } else {
-          notifyToast('warning', `[${albumRes.name}] No parent album found`);
+          notifyToast('warning', `[${albumRes.title}] No parent album found`);
         }
       }
 
@@ -295,7 +295,7 @@ const ArtistView = ({ ...rest }: any) => {
               id: data.id,
             }}
             imageHeight={185}
-            title={data.name}
+            title={data.title}
             showTitleTooltip
             subtitle={
               <>
@@ -393,7 +393,7 @@ const ArtistView = ({ ...rest }: any) => {
                                     }
                                   }}
                                 >
-                                  {artist.name}
+                                  {artist.title}
                                 </StyledTag>
                               ))}
                             </TagGroup>
@@ -455,7 +455,7 @@ const ArtistView = ({ ...rest }: any) => {
               data={misc.searchQuery !== '' ? filteredData : data.album}
               cardTitle={{
                 prefix: '/library/album',
-                property: 'name',
+                property: 'title',
                 urlProperty: 'albumId',
               }}
               cardSubtitle={{

--- a/src/components/library/ArtistView.tsx
+++ b/src/components/library/ArtistView.tsx
@@ -116,10 +116,10 @@ const ArtistView = ({ ...rest }: any) => {
 
   const handleFavorite = async () => {
     if (!data.starred) {
-      await star(data.id, 'artist');
+      await star({ id: data.id, type: 'artist' });
       queryClient.setQueryData(['artist', artistId], { ...data, starred: Date.now() });
     } else {
-      await unstar(data.id, 'artist');
+      await unstar({ id: data.id, type: 'artist' });
       queryClient.setQueryData(['artist', artistId], { ...data, starred: undefined });
     }
   };
@@ -154,7 +154,7 @@ const ArtistView = ({ ...rest }: any) => {
 
   const handleRowFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star(rowData.id, 'album');
+      await star({ id: rowData.id, type: 'album' });
       queryClient.setQueryData(['artist', artistId], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData?.album, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -164,7 +164,7 @@ const ArtistView = ({ ...rest }: any) => {
         return oldData;
       });
     } else {
-      await unstar(rowData.id, 'album');
+      await unstar({ id: rowData.id, type: 'album' });
       queryClient.setQueryData(['artist', artistId], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData?.album, { id: rowData.id }));
         starredIndices.forEach((index) => {

--- a/src/components/library/FolderList.tsx
+++ b/src/components/library/FolderList.tsx
@@ -61,7 +61,7 @@ const FolderList = () => {
   const filteredData = useSearchQuery(
     misc.searchQuery,
     folderData?.id ? folderData?.child : indexData,
-    ['name', 'title', 'artist', 'album', 'year', 'genre', 'path']
+    ['title', 'artist', 'album', 'year', 'genre', 'path']
   );
 
   useEffect(() => {
@@ -98,7 +98,7 @@ const FolderList = () => {
       const selected = folderData?.id ? folderData?.child : indexData?.child;
       dispatch(
         setPlayQueueByRowClick({
-          entries: selected.filter((entry: any) => entry.isDir === false),
+          entries: selected.filter((entry: any) => entry?.isDir === false),
           currentIndex: rowData.index,
           currentSongId: rowData.id,
           uniqueSongId: rowData.uniqueId,
@@ -149,8 +149,8 @@ const FolderList = () => {
           header={
             <GenericPageHeader
               title={`${
-                folderData?.name
-                  ? folderData.name
+                folderData?.title
+                  ? folderData.title
                   : isLoadingFolderData
                   ? 'Loading...'
                   : 'Select a folder'
@@ -167,7 +167,7 @@ const FolderList = () => {
                         data={musicFolders}
                         defaultValue={musicFolder}
                         valueKey="id"
-                        labelKey="name"
+                        labelKey="title"
                         onChange={(e: any) => {
                           setMusicFolder(e);
                         }}

--- a/src/components/library/FolderList.tsx
+++ b/src/components/library/FolderList.tsx
@@ -112,7 +112,7 @@ const FolderList = () => {
 
   const handleRowFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star(rowData.id, 'album');
+      await star({ id: rowData.id, type: 'album' });
       queryClient.setQueryData(['folder', folder.currentViewedFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.child, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -122,7 +122,7 @@ const FolderList = () => {
         return oldData;
       });
     } else {
-      await unstar(rowData.id, 'album');
+      await unstar({ id: rowData.id, type: 'album' });
       queryClient.setQueryData(['folder', folder.currentViewedFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.child, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -135,7 +135,7 @@ const FolderList = () => {
   };
 
   const handleRowRating = (rowData: any, e: number) => {
-    setRating(rowData.id, e);
+    setRating({ id: rowData.id, rating: e });
     dispatch(setRate({ id: [rowData.id], rating: e }));
   };
 

--- a/src/components/library/GenreList.tsx
+++ b/src/components/library/GenreList.tsx
@@ -14,8 +14,8 @@ import {
   toggleRangeSelected,
   toggleSelected,
 } from '../../redux/multiSelectSlice';
-import { getGenres } from '../../api/api';
 import { setActive } from '../../redux/albumSlice';
+import { apiController } from '../../api/controller';
 
 const GenreList = () => {
   const dispatch = useAppDispatch();
@@ -24,7 +24,7 @@ const GenreList = () => {
   const album = useAppSelector((state) => state.album);
   const misc = useAppSelector((state) => state.misc);
   const { isLoading, isError, data: genres, error }: any = useQuery(['genrePageList'], async () => {
-    const res = await getGenres();
+    const res = await apiController({ serverType: config.serverType, endpoint: 'getGenres' });
     return _.orderBy(res, 'songCount', 'desc');
   });
   const filteredData = useSearchQuery(misc.searchQuery, genres, ['title']);

--- a/src/components/library/GenreList.tsx
+++ b/src/components/library/GenreList.tsx
@@ -27,7 +27,7 @@ const GenreList = () => {
     const res = await getGenres();
     return _.orderBy(res, 'songCount', 'desc');
   });
-  const filteredData = useSearchQuery(misc.searchQuery, genres, ['value']);
+  const filteredData = useSearchQuery(misc.searchQuery, genres, ['title']);
 
   let timeout: any = null;
   const handleRowClick = (e: any, rowData: any, tableData: any) => {
@@ -48,12 +48,12 @@ const GenreList = () => {
   const handleRowDoubleClick = (rowData: any) => {
     window.clearTimeout(timeout);
     timeout = null;
-    dispatch(setActive({ ...album.active, filter: rowData.value }));
+    dispatch(setActive({ ...album.active, filter: rowData.title }));
     dispatch(clearSelected());
 
     // Needs a small delay or the filter won't set properly when navigating to the album list
     setTimeout(() => {
-      history.push(`/library/album?sortType=${rowData.value}`);
+      history.push(`/library/album?sortType=${rowData.title}`);
     }, 50);
   };
 

--- a/src/components/player/NowPlayingMiniView.tsx
+++ b/src/components/player/NowPlayingMiniView.tsx
@@ -254,10 +254,10 @@ const NowPlayingMiniView = () => {
 
   const handleRowFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star(rowData.id, 'music');
+      await star({ id: rowData.id, type: 'music' });
       dispatch(setStar({ id: [rowData.id], type: 'star' }));
     } else {
-      await unstar(rowData.id, 'music');
+      await unstar({ id: rowData.id, type: 'music' });
       dispatch(setStar({ id: [rowData.id], type: 'unstar' }));
     }
   };

--- a/src/components/player/NowPlayingMiniView.tsx
+++ b/src/components/player/NowPlayingMiniView.tsx
@@ -82,8 +82,8 @@ const NowPlayingMiniView = () => {
     const genresOrderedBySongCount = _.orderBy(res, 'songCount', 'desc');
     return genresOrderedBySongCount.map((genre: any) => {
       return {
-        label: `${genre.value} (${genre.songCount})`,
-        value: genre.value,
+        label: `${genre.title} (${genre.songCount})`,
+        title: genre.title,
         role: 'Genre',
       };
     });
@@ -190,7 +190,7 @@ const NowPlayingMiniView = () => {
 
     const cleanedSongs = filterPlayQueue(
       config.playback.filters,
-      res.song.filter((song: any) => {
+      res.filter((song: any) => {
         // Remove invalid songs that may break the player
         return song.bitRate && song.duration;
       })
@@ -210,7 +210,7 @@ const NowPlayingMiniView = () => {
         notifyToast(
           'info',
           getPlayedSongsNotification({
-            original: res.song.length,
+            original: res.length,
             filtered: cleanedSongs.count.filtered,
             type: 'play',
           })
@@ -224,7 +224,7 @@ const NowPlayingMiniView = () => {
         notifyToast(
           'info',
           getPlayedSongsNotification({
-            original: res.song.length,
+            original: res.length,
             filtered: cleanedSongs.count.filtered,
             type: 'add',
           })
@@ -238,7 +238,7 @@ const NowPlayingMiniView = () => {
         notifyToast(
           'info',
           getPlayedSongsNotification({
-            original: res.song.length,
+            original: res.length,
             filtered: cleanedSongs.count.filtered,
             type: 'add',
           })
@@ -300,7 +300,8 @@ const NowPlayingMiniView = () => {
                       <Whisper
                         ref={autoPlaylistTriggerRef}
                         placement="autoVertical"
-                        trigger="none"
+                        trigger="click"
+                        enterable
                         speaker={
                           <StyledPopover>
                             <ControlLabel>How many tracks? (1-500)*</ControlLabel>
@@ -356,6 +357,8 @@ const NowPlayingMiniView = () => {
                                 container={() => genrePickerContainerRef.current}
                                 data={!isLoadingGenres ? genres : []}
                                 value={randomPlaylistGenre}
+                                valueKey="title"
+                                labelKey="label"
                                 virtualized
                                 onChange={(e: string) => setRandomPlaylistGenre(e)}
                               />
@@ -370,7 +373,7 @@ const NowPlayingMiniView = () => {
                                 data={!isLoadingMusicFolders ? musicFolders : []}
                                 defaultValue={musicFolder}
                                 valueKey="id"
-                                labelKey="name"
+                                labelKey="title"
                                 onChange={(e: any) => {
                                   setMusicFolder(e);
                                 }}
@@ -411,15 +414,7 @@ const NowPlayingMiniView = () => {
                           </StyledPopover>
                         }
                       >
-                        <AutoPlaylistButton
-                          size="xs"
-                          noText
-                          onClick={() =>
-                            autoPlaylistTriggerRef.current.state.isOverlayShown
-                              ? autoPlaylistTriggerRef.current.close()
-                              : autoPlaylistTriggerRef.current.open()
-                          }
-                        />
+                        <AutoPlaylistButton size="xs" noText />
                       </Whisper>
                       <MoveTopButton
                         size="xs"

--- a/src/components/player/NowPlayingView.tsx
+++ b/src/components/player/NowPlayingView.tsx
@@ -265,16 +265,16 @@ const NowPlayingView = () => {
 
   const handleRowFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star(rowData.id, 'music');
+      await star({ id: rowData.id, type: 'music' });
       dispatch(setStar({ id: [rowData.id], type: 'star' }));
     } else {
-      await unstar(rowData.id, 'music');
+      await unstar({ id: rowData.id, type: 'music' });
       dispatch(setStar({ id: [rowData.id], type: 'unstar' }));
     }
   };
 
   const handleRowRating = (rowData: any, e: number) => {
-    setRating(rowData.id, e);
+    setRating({ id: rowData.id, rating: e });
     dispatch(setRate({ id: [rowData.id], rating: e }));
   };
 

--- a/src/components/player/NowPlayingView.tsx
+++ b/src/components/player/NowPlayingView.tsx
@@ -97,8 +97,8 @@ const NowPlayingView = () => {
     const genresOrderedBySongCount = _.orderBy(res, 'songCount', 'desc');
     return genresOrderedBySongCount.map((genre: any) => {
       return {
-        label: `${genre.value} (${genre.songCount})`,
-        value: genre.value,
+        label: `${genre.title} (${genre.songCount})`,
+        title: genre.title,
         role: 'Genre',
       };
     });
@@ -201,7 +201,7 @@ const NowPlayingView = () => {
 
     const cleanedSongs = filterPlayQueue(
       config.playback.filters,
-      res.song.filter((song: any) => {
+      res.filter((song: any) => {
         // Remove invalid songs that may break the player
         return song.bitRate && song.duration;
       })
@@ -221,7 +221,7 @@ const NowPlayingView = () => {
         notifyToast(
           'info',
           getPlayedSongsNotification({
-            original: res.song.length,
+            original: res.length,
             filtered: cleanedSongs.count.filtered,
             type: 'play',
           })
@@ -235,7 +235,7 @@ const NowPlayingView = () => {
         notifyToast(
           'info',
           getPlayedSongsNotification({
-            original: res.song.length,
+            original: res.length,
             filtered: cleanedSongs.count.filtered,
             type: 'add',
           })
@@ -249,7 +249,7 @@ const NowPlayingView = () => {
         notifyToast(
           'info',
           getPlayedSongsNotification({
-            original: res.song.length,
+            original: res.length,
             filtered: cleanedSongs.count.filtered,
             type: 'add',
           })
@@ -310,7 +310,8 @@ const NowPlayingView = () => {
                 <Whisper
                   ref={autoPlaylistTriggerRef}
                   placement="autoVertical"
-                  trigger="none"
+                  trigger="click"
+                  enterable
                   speaker={
                     <StyledPopover>
                       <ControlLabel>How many tracks? (1-500)*</ControlLabel>
@@ -367,6 +368,8 @@ const NowPlayingView = () => {
                           container={() => genrePickerContainerRef.current}
                           data={genres}
                           value={randomPlaylistGenre}
+                          valueKey="title"
+                          labelKey="label"
                           virtualized
                           onChange={(e: string) => setRandomPlaylistGenre(e)}
                         />
@@ -381,7 +384,7 @@ const NowPlayingView = () => {
                           data={musicFolders}
                           defaultValue={musicFolder}
                           valueKey="id"
-                          labelKey="name"
+                          labelKey="title"
                           onChange={(e: any) => {
                             setMusicFolder(e);
                           }}
@@ -421,14 +424,7 @@ const NowPlayingView = () => {
                     </StyledPopover>
                   }
                 >
-                  <AutoPlaylistButton
-                    size="sm"
-                    onClick={() =>
-                      autoPlaylistTriggerRef.current.state.isOverlayShown
-                        ? autoPlaylistTriggerRef.current.close()
-                        : autoPlaylistTriggerRef.current.open()
-                    }
-                  />
+                  <AutoPlaylistButton size="sm" />
                 </Whisper>
                 <ButtonGroup>
                   <MoveTopButton

--- a/src/components/player/PlayerBar.tsx
+++ b/src/components/player/PlayerBar.tsx
@@ -273,7 +273,7 @@ const PlayerBar = () => {
 
   const handleFavorite = async () => {
     if (!playQueue[currentEntryList][playQueue.currentIndex].starred) {
-      await star(playQueue[currentEntryList][playQueue.currentIndex].id, 'music');
+      await star({ id: playQueue[currentEntryList][playQueue.currentIndex].id, type: 'music' });
       dispatch(
         setStar({
           id: [playQueue[currentEntryList][playQueue.currentIndex].id],
@@ -281,7 +281,7 @@ const PlayerBar = () => {
         })
       );
     } else {
-      await unstar(playQueue[currentEntryList][playQueue.currentIndex].id, 'music');
+      await unstar({ id: playQueue[currentEntryList][playQueue.currentIndex].id, type: 'music' });
       dispatch(
         setStar({
           id: [playQueue[currentEntryList][playQueue.currentIndex].id],

--- a/src/components/player/PlayerBar.tsx
+++ b/src/components/player/PlayerBar.tsx
@@ -29,18 +29,20 @@ import { setStatus, resetPlayer } from '../../redux/playerSlice';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import Player from './Player';
 import CustomTooltip from '../shared/CustomTooltip';
-import { star, unstar } from '../../api/api';
 import placeholderImg from '../../img/placeholder.jpg';
 import DebugWindow from '../debug/DebugWindow';
 import { CoverArtWrapper } from '../layout/styled';
 import { getCurrentEntryList, isCached } from '../../shared/utils';
 import { StyledPopover } from '../shared/styled';
+import { apiController } from '../../api/controller';
+import { Server } from '../../types';
 
 const PlayerBar = () => {
   const queryClient = useQueryClient();
   const playQueue = useAppSelector((state) => state.playQueue);
   const player = useAppSelector((state) => state.player);
   const misc = useAppSelector((state) => state.misc);
+  const config = useAppSelector((state) => state.config);
   const dispatch = useAppDispatch();
   const [seek, setSeek] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
@@ -273,7 +275,14 @@ const PlayerBar = () => {
 
   const handleFavorite = async () => {
     if (!playQueue[currentEntryList][playQueue.currentIndex].starred) {
-      await star({ id: playQueue[currentEntryList][playQueue.currentIndex].id, type: 'music' });
+      await apiController({
+        serverType: config.serverType,
+        endpoint: 'star',
+        args:
+          config.serverType === Server.Subsonic
+            ? { id: playQueue[currentEntryList][playQueue.currentIndex].id, type: 'music' }
+            : null,
+      });
       dispatch(
         setStar({
           id: [playQueue[currentEntryList][playQueue.currentIndex].id],
@@ -281,7 +290,14 @@ const PlayerBar = () => {
         })
       );
     } else {
-      await unstar({ id: playQueue[currentEntryList][playQueue.currentIndex].id, type: 'music' });
+      await apiController({
+        serverType: config.serverType,
+        endpoint: 'unstar',
+        args:
+          config.serverType === Server.Subsonic
+            ? { id: playQueue[currentEntryList][playQueue.currentIndex].id, type: 'music' }
+            : null,
+      });
       dispatch(
         setStar({
           id: [playQueue[currentEntryList][playQueue.currentIndex].id],

--- a/src/components/playlist/PlaylistList.tsx
+++ b/src/components/playlist/PlaylistList.tsx
@@ -4,7 +4,6 @@ import { useHistory } from 'react-router-dom';
 import { Form, Whisper } from 'rsuite';
 import settings from 'electron-settings';
 import useSearchQuery from '../../hooks/useSearchQuery';
-import { createPlaylist } from '../../api/api';
 import ListViewType from '../viewtypes/ListViewType';
 import PageLoader from '../loader/PageLoader';
 import GenericPage from '../layout/GenericPage';
@@ -39,7 +38,11 @@ const PlaylistList = () => {
 
   const handleCreatePlaylist = async (name: string) => {
     try {
-      const res = await createPlaylist({ name });
+      const res = await apiController({
+        serverType: config.serverType,
+        endpoint: 'createPlaylist',
+        args: { name },
+      });
 
       if (isFailedResponse(res)) {
         notifyToast('error', errorMessages(res)[0]);

--- a/src/components/playlist/PlaylistList.tsx
+++ b/src/components/playlist/PlaylistList.tsx
@@ -29,13 +29,12 @@ const PlaylistList = () => {
   const config = useAppSelector((state) => state.config);
   const misc = useAppSelector((state) => state.misc);
   const playlistTriggerRef = useRef<any>();
-  const [sortBy] = useState('name');
   const [newPlaylistName, setNewPlaylistName] = useState('');
   const [viewType, setViewType] = useState(settings.getSync('playlistViewType') || 'list');
-  const { isLoading, isError, data: playlists, error }: any = useQuery(['playlists', sortBy], () =>
-    getPlaylists(sortBy)
+  const { isLoading, isError, data: playlists, error }: any = useQuery(['playlists'], () =>
+    getPlaylists()
   );
-  const filteredData = useSearchQuery(misc.searchQuery, playlists, ['name', 'comment', 'owner']);
+  const filteredData = useSearchQuery(misc.searchQuery, playlists, ['title', 'comment', 'owner']);
 
   const handleCreatePlaylist = async (name: string) => {
     try {
@@ -174,7 +173,7 @@ const PlaylistList = () => {
           data={misc.searchQuery === '' ? playlists : filteredData}
           cardTitle={{
             prefix: 'playlist',
-            property: 'name',
+            property: 'title',
             urlProperty: 'id',
           }}
           cardSubtitle={{

--- a/src/components/playlist/PlaylistList.tsx
+++ b/src/components/playlist/PlaylistList.tsx
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router-dom';
 import { Form, Whisper } from 'rsuite';
 import settings from 'electron-settings';
 import useSearchQuery from '../../hooks/useSearchQuery';
-import { createPlaylist, getPlaylists } from '../../api/api';
+import { createPlaylist } from '../../api/api';
 import ListViewType from '../viewtypes/ListViewType';
 import PageLoader from '../loader/PageLoader';
 import GenericPage from '../layout/GenericPage';
@@ -21,6 +21,7 @@ import {
   toggleRangeSelected,
   toggleSelected,
 } from '../../redux/multiSelectSlice';
+import { apiController } from '../../api/controller';
 
 const PlaylistList = () => {
   const dispatch = useAppDispatch();
@@ -32,7 +33,7 @@ const PlaylistList = () => {
   const [newPlaylistName, setNewPlaylistName] = useState('');
   const [viewType, setViewType] = useState(settings.getSync('playlistViewType') || 'list');
   const { isLoading, isError, data: playlists, error }: any = useQuery(['playlists'], () =>
-    getPlaylists()
+    apiController({ serverType: config.serverType, endpoint: 'getPlaylists' })
   );
   const filteredData = useSearchQuery(misc.searchQuery, playlists, ['title', 'comment', 'owner']);
 

--- a/src/components/playlist/PlaylistList.tsx
+++ b/src/components/playlist/PlaylistList.tsx
@@ -38,7 +38,7 @@ const PlaylistList = () => {
 
   const handleCreatePlaylist = async (name: string) => {
     try {
-      const res = await createPlaylist(name);
+      const res = await createPlaylist({ name });
 
       if (isFailedResponse(res)) {
         notifyToast('error', errorMessages(res)[0]);

--- a/src/components/playlist/PlaylistView.tsx
+++ b/src/components/playlist/PlaylistView.tsx
@@ -219,7 +219,7 @@ const PlaylistView = ({ ...rest }) => {
 
       // Smaller playlists can use the safe /createPlaylist method of saving
       if (playlistData.length <= 400 && !recovery) {
-        res = await updatePlaylistSongs(data.id, playlistData);
+        res = await updatePlaylistSongs({ id: data.id, entry: playlistData });
         if (isFailedResponse(res)) {
           notifyToast('error', errorMessages(res)[0]);
         } else {
@@ -238,7 +238,7 @@ const PlaylistView = ({ ...rest }) => {
           return dispatch(removeProcessingPlaylist(data.id));
         }
 
-        res = await updatePlaylistSongsLg(data.id, playlistData);
+        res = await updatePlaylistSongsLg({ id: data.id, entry: playlistData });
 
         if (isFailedResponse(res)) {
           res.forEach((response) => {
@@ -282,7 +282,12 @@ const PlaylistView = ({ ...rest }) => {
 
   const handleEdit = async () => {
     setIsSubmittingEdit(true);
-    const res = await updatePlaylist(data.id, editName, editDescription, editPublic);
+    const res = await updatePlaylist({
+      id: data.id,
+      name: editName,
+      comment: editDescription,
+      isPublic: editPublic,
+    });
 
     if (isFailedResponse(res)) {
       notifyToast('error', errorMessages(res)[0]);
@@ -298,7 +303,7 @@ const PlaylistView = ({ ...rest }) => {
 
   const handleDelete = async () => {
     try {
-      const res = await deletePlaylist(data.id);
+      const res = await deletePlaylist({ id: data.id });
 
       if (isFailedResponse(res)) {
         notifyToast('error', res.error.message);
@@ -324,7 +329,7 @@ const PlaylistView = ({ ...rest }) => {
 
   const handleRowFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star(rowData.id, 'music');
+      await star({ id: rowData.id, type: 'music' });
       dispatch(setStar({ id: [rowData.id], type: 'star' }));
       dispatch(setPlaylistStar({ id: [rowData.id], type: 'star' }));
 
@@ -337,7 +342,7 @@ const PlaylistView = ({ ...rest }) => {
         return oldData;
       });
     } else {
-      await unstar(rowData.id, 'music');
+      await unstar({ id: rowData.id, type: 'music' });
       dispatch(setStar({ id: [rowData.id], type: 'unstar' }));
       dispatch(setPlaylistStar({ id: [rowData.id], type: 'unstar' }));
 
@@ -353,7 +358,7 @@ const PlaylistView = ({ ...rest }) => {
   };
 
   const handleRowRating = (rowData: any, e: number) => {
-    setRating(rowData.id, e);
+    setRating({ id: rowData.id, rating: e });
     dispatch(setRate({ id: [rowData.id], rating: e }));
     dispatch(setPlaylistRate({ id: [rowData.id], rating: e }));
   };

--- a/src/components/playlist/PlaylistView.tsx
+++ b/src/components/playlist/PlaylistView.tsx
@@ -135,7 +135,7 @@ const PlaylistView = ({ ...rest }) => {
   useEffect(() => {
     // Set the local playlist data on any changes
     dispatch(setPlaylistData(data?.song));
-    setEditName(data?.name);
+    setEditName(data?.title);
     setEditDescription(data?.comment);
     setEditPublic(data?.public);
   }, [data, dispatch]);
@@ -402,7 +402,7 @@ const PlaylistView = ({ ...rest }) => {
             id: data.id,
           }}
           imageHeight={184}
-          title={data.name}
+          title={data.title}
           subtitle={
             <div>
               <PageHeaderSubtitleDataLine $top>

--- a/src/components/playlist/PlaylistView.tsx
+++ b/src/components/playlist/PlaylistView.tsx
@@ -19,7 +19,6 @@ import {
 import {
   clearPlaylist,
   deletePlaylist,
-  getPlaylist,
   updatePlaylistSongsLg,
   updatePlaylistSongs,
   updatePlaylist,
@@ -76,6 +75,7 @@ import {
 } from '../../redux/playlistSlice';
 import { PageHeaderSubtitleDataLine } from '../layout/styled';
 import CustomTooltip from '../shared/CustomTooltip';
+import { apiController } from '../../api/controller';
 
 interface PlaylistParams {
   id: string;
@@ -94,8 +94,13 @@ const PlaylistView = ({ ...rest }) => {
   const { id } = useParams<PlaylistParams>();
   const playlistId = rest.id ? rest.id : id;
   const { isLoading, isError, data, error }: any = useQuery(['playlist', playlistId], () =>
-    getPlaylist(playlistId)
+    apiController({
+      serverType: config.serverType,
+      endpoint: 'getPlaylist',
+      args: { id: playlistId },
+    })
   );
+
   const [customPlaylistImage, setCustomPlaylistImage] = useState<string | string[]>(
     'img/placeholder.jpg'
   );

--- a/src/components/search/SearchView.tsx
+++ b/src/components/search/SearchView.tsx
@@ -164,7 +164,7 @@ const SearchView = () => {
             data={data.artist}
             cardTitle={{
               prefix: '/library/artist',
-              property: 'name',
+              property: 'title',
               urlProperty: 'id',
             }}
             cardSubtitle={{
@@ -181,7 +181,7 @@ const SearchView = () => {
             data={data.album}
             cardTitle={{
               prefix: '/library/album',
-              property: 'name',
+              property: 'title',
               urlProperty: 'albumId',
             }}
             cardSubtitle={{

--- a/src/components/search/SearchView.tsx
+++ b/src/components/search/SearchView.tsx
@@ -3,7 +3,6 @@ import _ from 'lodash';
 import settings from 'electron-settings';
 import { useHistory } from 'react-router-dom';
 import { useQuery, useQueryClient } from 'react-query';
-import { getSearch, star, unstar } from '../../api/api';
 import useRouterQuery from '../../hooks/useRouterQuery';
 import GenericPage from '../layout/GenericPage';
 import GenericPageHeader from '../layout/GenericPageHeader';
@@ -20,6 +19,8 @@ import { fixPlayer2Index, setPlayQueueByRowClick } from '../../redux/playQueueSl
 import { setStatus } from '../../redux/playerSlice';
 import ListViewTable from '../viewtypes/ListViewTable';
 import { SectionTitle, SectionTitleWrapper, StyledPanel } from '../shared/styled';
+import { apiController } from '../../api/controller';
+import { Server } from '../../types';
 
 const SearchView = () => {
   const dispatch = useAppDispatch();
@@ -40,7 +41,14 @@ const SearchView = () => {
   }, [folder]);
 
   const { isLoading, isError, data, error }: any = useQuery(['search', urlQuery, musicFolder], () =>
-    getSearch({ query: urlQuery, songCount: 100, musicFolderId: musicFolder })
+    apiController({
+      serverType: config.serverType,
+      endpoint: 'getSearch',
+      args:
+        config.serverType === Server.Subsonic
+          ? { query: urlQuery, songCount: 100, musicFolderId: musicFolder }
+          : null,
+    })
   );
 
   let timeout: any = null;
@@ -83,7 +91,11 @@ const SearchView = () => {
 
   const handleRowFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star({ id: rowData.id, type: 'music' });
+      await apiController({
+        serverType: config.serverType,
+        endpoint: 'star',
+        args: config.serverType === Server.Subsonic ? { id: rowData.id, type: 'music' } : null,
+      });
       queryClient.setQueryData(['search', urlQuery, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.song, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -93,7 +105,11 @@ const SearchView = () => {
         return oldData;
       });
     } else {
-      await unstar({ id: rowData.id, type: 'album' });
+      await apiController({
+        serverType: config.serverType,
+        endpoint: 'unstar',
+        args: config.serverType === Server.Subsonic ? { id: rowData.id, type: 'album' } : null,
+      });
       queryClient.setQueryData(['search', urlQuery, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.song, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -107,7 +123,11 @@ const SearchView = () => {
 
   const handleArtistFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star({ id: rowData.id, type: 'artist' });
+      await apiController({
+        serverType: config.serverType,
+        endpoint: 'star',
+        args: config.serverType === Server.Subsonic ? { id: rowData.id, type: 'artist' } : null,
+      });
       queryClient.setQueryData(['search', urlQuery, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.artist, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -117,7 +137,11 @@ const SearchView = () => {
         return oldData;
       });
     } else {
-      await unstar({ id: rowData.id, type: 'album' });
+      await apiController({
+        serverType: config.serverType,
+        endpoint: 'unstar',
+        args: config.serverType === Server.Subsonic ? { id: rowData.id, type: 'album' } : null,
+      });
       queryClient.setQueryData(['search', urlQuery, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.artist, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -131,7 +155,11 @@ const SearchView = () => {
 
   const handleAlbumFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star({ id: rowData.id, type: 'artist' });
+      await apiController({
+        serverType: config.serverType,
+        endpoint: 'star',
+        args: config.serverType === Server.Subsonic ? { id: rowData.id, type: 'artist' } : null,
+      });
       queryClient.setQueryData(['search', urlQuery, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.album, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -141,7 +169,11 @@ const SearchView = () => {
         return oldData;
       });
     } else {
-      await unstar({ id: rowData.id, type: 'album' });
+      await apiController({
+        serverType: config.serverType,
+        endpoint: 'unstar',
+        args: config.serverType === Server.Subsonic ? { id: rowData.id, type: 'album' } : null,
+      });
       queryClient.setQueryData(['search', urlQuery, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.album, { id: rowData.id }));
         starredIndices.forEach((index) => {

--- a/src/components/search/SearchView.tsx
+++ b/src/components/search/SearchView.tsx
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import settings from 'electron-settings';
 import { useHistory } from 'react-router-dom';
 import { useQuery, useQueryClient } from 'react-query';
-import { search3, star, unstar } from '../../api/api';
+import { getSearch, star, unstar } from '../../api/api';
 import useRouterQuery from '../../hooks/useRouterQuery';
 import GenericPage from '../layout/GenericPage';
 import GenericPageHeader from '../layout/GenericPageHeader';
@@ -40,7 +40,7 @@ const SearchView = () => {
   }, [folder]);
 
   const { isLoading, isError, data, error }: any = useQuery(['search', urlQuery, musicFolder], () =>
-    search3({ query: urlQuery, songCount: 100, musicFolderId: musicFolder })
+    getSearch({ query: urlQuery, songCount: 100, musicFolderId: musicFolder })
   );
 
   let timeout: any = null;
@@ -83,7 +83,7 @@ const SearchView = () => {
 
   const handleRowFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star(rowData.id, 'music');
+      await star({ id: rowData.id, type: 'music' });
       queryClient.setQueryData(['search', urlQuery, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.song, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -93,7 +93,7 @@ const SearchView = () => {
         return oldData;
       });
     } else {
-      await unstar(rowData.id, 'album');
+      await unstar({ id: rowData.id, type: 'album' });
       queryClient.setQueryData(['search', urlQuery, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.song, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -107,7 +107,7 @@ const SearchView = () => {
 
   const handleArtistFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star(rowData.id, 'artist');
+      await star({ id: rowData.id, type: 'artist' });
       queryClient.setQueryData(['search', urlQuery, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.artist, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -117,7 +117,7 @@ const SearchView = () => {
         return oldData;
       });
     } else {
-      await unstar(rowData.id, 'album');
+      await unstar({ id: rowData.id, type: 'album' });
       queryClient.setQueryData(['search', urlQuery, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.artist, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -131,7 +131,7 @@ const SearchView = () => {
 
   const handleAlbumFavorite = async (rowData: any) => {
     if (!rowData.starred) {
-      await star(rowData.id, 'artist');
+      await star({ id: rowData.id, type: 'artist' });
       queryClient.setQueryData(['search', urlQuery, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.album, { id: rowData.id }));
         starredIndices.forEach((index) => {
@@ -141,7 +141,7 @@ const SearchView = () => {
         return oldData;
       });
     } else {
-      await unstar(rowData.id, 'album');
+      await unstar({ id: rowData.id, type: 'album' });
       queryClient.setQueryData(['search', urlQuery, musicFolder], (oldData: any) => {
         const starredIndices = _.keys(_.pickBy(oldData.album, { id: rowData.id }));
         starredIndices.forEach((index) => {

--- a/src/components/settings/Config.tsx
+++ b/src/components/settings/Config.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { shell } from 'electron';
 import { Whisper, Nav, ButtonToolbar } from 'rsuite';
-import { startScan, getScanStatus } from '../../api/api';
 import GenericPage from '../layout/GenericPage';
 import DisconnectButton from './DisconnectButton';
 import GenericPageHeader from '../layout/GenericPageHeader';
@@ -18,6 +17,7 @@ import packageJson from '../../package.json';
 import ServerConfig from './ConfigPanels/ServerConfig';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { setActive } from '../../redux/configSlice';
+import { apiController } from '../../api/controller';
 
 const GITHUB_RELEASE_URL = 'https://api.github.com/repos/jeffvli/sonixd/releases?per_page=3';
 
@@ -40,7 +40,7 @@ const Config = () => {
 
   useEffect(() => {
     // Check scan status on render
-    getScanStatus()
+    apiController({ serverType: config.serverType, endpoint: 'getScanStatus' })
       .then((status) => {
         if (status.scanning) {
           return setIsScanning(true);
@@ -49,13 +49,13 @@ const Config = () => {
         return setScanProgress(0);
       })
       .catch((err) => console.log(err));
-  }, []);
+  }, [config.serverType]);
 
   useEffect(() => {
     // Reload scan status on interval during scan
     if (isScanning) {
       const interval = setInterval(() => {
-        getScanStatus()
+        apiController({ serverType: config.serverType, endpoint: 'getScanStatus' })
           .then((status) => {
             if (status.scanning) {
               return setScanProgress(status.count);
@@ -69,7 +69,7 @@ const Config = () => {
       return () => clearInterval(interval);
     }
     return () => clearInterval();
-  }, [isScanning]);
+  }, [config.serverType, isScanning]);
 
   return (
     <GenericPage
@@ -125,7 +125,7 @@ const Config = () => {
               <StyledButton
                 size="sm"
                 onClick={async () => {
-                  startScan();
+                  apiController({ serverType: config.serverType, endpoint: 'startScan' });
                   setIsScanning(true);
                 }}
                 disabled={isScanning}

--- a/src/components/settings/ConfigPanels/ServerConfig.tsx
+++ b/src/components/settings/ConfigPanels/ServerConfig.tsx
@@ -5,13 +5,16 @@ import { CheckboxGroup } from 'rsuite';
 import { ConfigPanel } from '../styled';
 import { StyledCheckbox, StyledInputPicker, StyledInputPickerContainer } from '../../shared/styled';
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
-import { getMusicFolders } from '../../../api/api';
 import { setAppliedFolderViews, setMusicFolder } from '../../../redux/folderSlice';
+import { apiController } from '../../../api/controller';
 
 const ServerConfig = () => {
   const dispatch = useAppDispatch();
   const folder = useAppSelector((state) => state.folder);
-  const { isLoading, data: musicFolders } = useQuery(['musicFolders'], getMusicFolders);
+  const config = useAppSelector((state) => state.config);
+  const { isLoading, data: musicFolders } = useQuery(['musicFolders'], () =>
+    apiController({ serverType: config.serverType, endpoint: 'getMusicFolders' })
+  );
   const musicFolderPickerContainerRef = useRef(null);
 
   return (

--- a/src/components/settings/DisconnectButton.tsx
+++ b/src/components/settings/DisconnectButton.tsx
@@ -2,20 +2,27 @@ import React from 'react';
 import settings from 'electron-settings';
 import { StyledButton } from '../shared/styled';
 
-const DisconnectButton = () => {
-  const handleDisconnect = () => {
-    localStorage.removeItem('server');
-    localStorage.removeItem('username');
-    localStorage.removeItem('salt');
-    localStorage.removeItem('hash');
+export const handleDisconnect = () => {
+  localStorage.removeItem('server');
+  localStorage.removeItem('username');
+  localStorage.removeItem('userId');
+  localStorage.removeItem('password');
+  localStorage.removeItem('salt');
+  localStorage.removeItem('hash');
+  localStorage.removeItem('token');
 
-    settings.setSync('server', '');
-    settings.setSync('serverBase64', '');
-    settings.setSync('username', '');
-    settings.setSync('salt', '');
-    settings.setSync('hash', '');
-    window.location.reload();
-  };
+  settings.setSync('server', '');
+  settings.setSync('serverBase64', '');
+  settings.setSync('username', '');
+  settings.setSync('userId', '');
+  settings.setSync('password', '');
+  settings.setSync('salt', '');
+  settings.setSync('hash', '');
+  settings.setSync('token', '');
+  window.location.reload();
+};
+
+const DisconnectButton = () => {
   return (
     <StyledButton onClick={handleDisconnect} size="sm">
       Disconnect

--- a/src/components/settings/ListViewColumns.ts
+++ b/src/components/settings/ListViewColumns.ts
@@ -476,7 +476,7 @@ export const albumColumnList = [
     label: 'Title',
     value: {
       id: 'Title',
-      dataKey: 'name',
+      dataKey: 'title',
       alignment: 'left',
       resizable: true,
       width: 300,
@@ -594,7 +594,7 @@ export const albumColumnListAuto = [
     label: 'Title',
     value: {
       id: 'Title',
-      dataKey: 'name',
+      dataKey: 'title',
       alignment: 'left',
       flexGrow: 5,
       label: 'Title',
@@ -752,7 +752,7 @@ export const playlistColumnList = [
     label: 'Title',
     value: {
       id: 'Title',
-      dataKey: 'name',
+      dataKey: 'title',
       alignment: 'left',
       resizable: true,
       width: 300,
@@ -879,7 +879,7 @@ export const playlistColumnListAuto = [
     label: 'Title',
     value: {
       id: 'Title',
-      dataKey: 'name',
+      dataKey: 'title',
       alignment: 'left',
       flexGrow: 5,
       label: 'Title',
@@ -956,14 +956,14 @@ export const artistColumnList = [
     },
   },
   {
-    label: 'Name',
+    label: 'Title',
     value: {
-      id: 'Name',
-      dataKey: 'name',
+      id: 'Title',
+      dataKey: 'title',
       alignment: 'left',
       resizable: true,
       width: 300,
-      label: 'Name',
+      label: 'Title',
     },
   },
 ];
@@ -1012,13 +1012,13 @@ export const artistColumnListAuto = [
     },
   },
   {
-    label: 'Name',
+    label: 'Title',
     value: {
-      id: 'Name',
-      dataKey: 'name',
+      id: 'Title',
+      dataKey: 'title',
       alignment: 'left',
       flexGrow: 5,
-      label: 'Name',
+      label: 'Title',
     },
   },
 ];
@@ -1028,13 +1028,13 @@ export const artistColumnPicker = [
   { label: 'Album Count' },
   { label: 'CoverArt' },
   { label: 'Favorite' },
-  { label: 'Name' },
+  { label: 'Title' },
 ];
 
 export const genreColumnPicker = [
   { label: '#' },
   { label: 'Album Count' },
-  { label: 'Name' },
+  { label: 'Title' },
   { label: 'Track Count' },
 ];
 
@@ -1062,14 +1062,14 @@ export const genreColumnList = [
     },
   },
   {
-    label: 'Name',
+    label: 'Title',
     value: {
-      id: 'Name',
-      dataKey: 'name',
+      id: 'Title',
+      dataKey: 'title',
       alignment: 'left',
       resizable: true,
       width: 300,
-      label: 'Name',
+      label: 'Title',
     },
   },
   {
@@ -1108,17 +1108,17 @@ export const genreColumnListAuto = [
     },
   },
   {
-    label: 'Name',
+    label: 'Title',
     value: {
-      id: 'Name',
-      dataKey: 'name',
+      id: 'Title',
+      dataKey: 'title',
       alignment: 'left',
       flexGrow: 5,
-      label: 'Name',
+      label: 'Title',
     },
   },
   {
-    label: 'Tracks',
+    label: 'Track Count',
     value: {
       id: 'Tracks',
       dataKey: 'songCount',

--- a/src/components/settings/Login.tsx
+++ b/src/components/settings/Login.tsx
@@ -1,22 +1,29 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import md5 from 'md5';
 import randomstring from 'randomstring';
 import settings from 'electron-settings';
 import { Button, Form, ControlLabel, Message } from 'rsuite';
 import axios from 'axios';
 import setDefaultSettings from '../shared/setDefaultSettings';
-import { StyledCheckbox, StyledInput } from '../shared/styled';
+import {
+  StyledCheckbox,
+  StyledInput,
+  StyledInputPicker,
+  StyledInputPickerContainer,
+} from '../shared/styled';
 import { LoginPanel } from './styled';
 import GenericPage from '../layout/GenericPage';
 import logo from '../../../assets/icon.png';
 import { mockSettings } from '../../shared/mockSettings';
 
 const Login = () => {
+  const [serverType, setServerType] = useState('subsonic');
   const [serverName, setServerName] = useState('');
   const [userName, setUserName] = useState('');
   const [password, setPassword] = useState('');
   const [legacyAuth, setLegacyAuth] = useState(false);
   const [message, setMessage] = useState('');
+  const serverTypePickerRef = useRef(null);
 
   const handleConnect = async () => {
     setMessage('');
@@ -50,6 +57,7 @@ const Login = () => {
 
     localStorage.setItem('server', cleanServerName);
     localStorage.setItem('serverBase64', btoa(cleanServerName));
+    localStorage.setItem('serverType', 'subsonic');
     localStorage.setItem('username', userName);
     localStorage.setItem('password', password);
     localStorage.setItem('salt', salt);
@@ -57,6 +65,7 @@ const Login = () => {
 
     settings.setSync('server', cleanServerName);
     settings.setSync('serverBase64', btoa(cleanServerName));
+    settings.setSync('serverType', 'subsonic');
     settings.setSync('username', userName);
     settings.setSync('password', password);
     settings.setSync('salt', salt);
@@ -64,7 +73,52 @@ const Login = () => {
 
     // Set defaults on login
     setDefaultSettings(false);
+    window.location.reload();
+  };
 
+  const handleConnectJellyfin = async () => {
+    setMessage('');
+    const cleanServerName = serverName.replace(/\/$/, '');
+    const deviceId = randomstring.generate({ length: 12, charset: 'alphanumeric' });
+
+    try {
+      const { data } = await axios.post(
+        `${cleanServerName}/users/authenticatebyname`,
+        {
+          Username: userName,
+          Pw: password,
+        },
+        {
+          headers: {
+            'X-Emby-Authorization': `MediaBrowser Client="Sonixd", Device="PC", DeviceId="${deviceId}", Version="0.1.0"`,
+          },
+        }
+      );
+
+      localStorage.setItem('server', cleanServerName);
+      localStorage.setItem('serverBase64', btoa(cleanServerName));
+      localStorage.setItem('serverType', 'jellyfin');
+      localStorage.setItem('username', data.User.Id);
+      localStorage.setItem('token', data.AccessToken);
+      localStorage.setItem('deviceId', deviceId);
+
+      settings.setSync('server', cleanServerName);
+      settings.setSync('serverBase64', btoa(cleanServerName));
+      settings.setSync('serverType', 'jellyfin');
+      settings.setSync('username', data.User.Id);
+      settings.setSync('token', data.AccessToken);
+      settings.setSync('deviceId', deviceId);
+    } catch (err) {
+      if (err instanceof Error) {
+        setMessage(`${err.message}`);
+        return;
+      }
+      setMessage('An unknown error occurred');
+      return;
+    }
+
+    // Set defaults on login
+    setDefaultSettings(false);
     window.location.reload();
   };
 
@@ -78,6 +132,22 @@ const Login = () => {
         <br />
         {message !== '' && <Message type="error" description={message} />}
         <Form id="login-form" fluid style={{ paddingTop: '20px' }}>
+          <StyledInputPickerContainer ref={serverTypePickerRef}>
+            <ControlLabel>Server type</ControlLabel>
+            <StyledInputPicker
+              container={() => serverTypePickerRef.current}
+              cleanable={false}
+              data={[
+                { label: 'Subsonic', value: 'subsonic' },
+                { label: 'Jellyfin', value: 'jellyfin' },
+              ]}
+              defaultValue="subsonic"
+              valueKey="value"
+              labelKey="label"
+              onChange={(e: 'subsonic' | 'jellyfin') => setServerType(e)}
+            />
+          </StyledInputPickerContainer>
+          <br />
           <ControlLabel>Server</ControlLabel>
           <StyledInput
             id="login-servername"
@@ -103,28 +173,32 @@ const Login = () => {
             onChange={(e: string) => setPassword(e)}
           />
           <br />
-          <StyledCheckbox
-            defaultChecked={
-              process.env.NODE_ENV === 'test'
-                ? mockSettings
-                : Boolean(settings.getSync('legacyAuth'))
-            }
-            checked={legacyAuth}
-            onChange={(_v: any, e: boolean) => {
-              settings.setSync('legacyAuth', e);
-              setLegacyAuth(e);
-            }}
-          >
-            Legacy auth (plaintext)
-          </StyledCheckbox>
-          <br />
+          {serverType === 'subsonic' && (
+            <>
+              <StyledCheckbox
+                defaultChecked={
+                  process.env.NODE_ENV === 'test'
+                    ? mockSettings
+                    : Boolean(settings.getSync('legacyAuth'))
+                }
+                checked={legacyAuth}
+                onChange={(_v: any, e: boolean) => {
+                  settings.setSync('legacyAuth', e);
+                  setLegacyAuth(e);
+                }}
+              >
+                Legacy auth (plaintext)
+              </StyledCheckbox>
+              <br />
+            </>
+          )}
           <Button
             id="login-button"
             appearance="primary"
             type="submit"
             color="green"
             block
-            onClick={handleConnect}
+            onClick={serverType === 'subsonic' ? handleConnect : handleConnectJellyfin}
           >
             Connect
           </Button>

--- a/src/components/shared/ContextMenu.tsx
+++ b/src/components/shared/ContextMenu.tsx
@@ -14,8 +14,8 @@ import {
   getAlbum,
   getPlaylist,
   deletePlaylist,
-  getAllArtistSongs,
-  getAllDirectorySongs,
+  getArtistSongs,
+  getDirectorySongs,
 } from '../../api/api';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import {
@@ -120,7 +120,7 @@ export const GlobalContextMenu = () => {
   const [indexToMoveTo, setIndexToMoveTo] = useState(0);
   const playlistPickerContainerRef = useRef(null);
 
-  const { data: playlists }: any = useQuery(['playlists', 'name'], () => getPlaylists('name'));
+  const { data: playlists }: any = useQuery(['playlists'], () => getPlaylists());
 
   const handlePlay = async () => {
     dispatch(setContextMenu({ show: false }));
@@ -135,7 +135,7 @@ export const GlobalContextMenu = () => {
         });
 
       for (let i = 0; i < folders.length; i += 1) {
-        promises.push(getAllDirectorySongs({ id: folders[i].id }));
+        promises.push(getDirectorySongs({ id: folders[i].id }));
       }
 
       const res = await Promise.all(promises);
@@ -172,7 +172,7 @@ export const GlobalContextMenu = () => {
       notifyToast('info', getPlayedSongsNotification({ ...songs.count, type: 'play' }));
     } else if (misc.contextMenu.type === 'album') {
       for (let i = 0; i < multiSelect.selected.length; i += 1) {
-        promises.push(getAlbum(multiSelect.selected[i].id));
+        promises.push(getAlbum({ id: multiSelect.selected[i].id }));
       }
 
       const res = await Promise.all(promises);
@@ -191,7 +191,7 @@ export const GlobalContextMenu = () => {
       notifyToast('info', getPlayedSongsNotification({ ...songs.count, type: 'play' }));
     } else if (misc.contextMenu.type === 'artist') {
       for (let i = 0; i < multiSelect.selected.length; i += 1) {
-        promises.push(getAllArtistSongs(multiSelect.selected[i].id));
+        promises.push(getArtistSongs({ id: multiSelect.selected[i].id }));
       }
 
       const res = await Promise.all(promises);
@@ -223,7 +223,7 @@ export const GlobalContextMenu = () => {
         });
 
       for (let i = 0; i < folders.length; i += 1) {
-        promises.push(getAllDirectorySongs({ id: multiSelect.selected[i].id }));
+        promises.push(getDirectorySongs({ id: multiSelect.selected[i].id }));
       }
 
       const res = await Promise.all(promises);
@@ -252,7 +252,7 @@ export const GlobalContextMenu = () => {
       notifyToast('info', getPlayedSongsNotification({ ...songs.count, type: 'add' }));
     } else if (misc.contextMenu.type === 'album') {
       for (let i = 0; i < multiSelect.selected.length; i += 1) {
-        promises.push(getAlbum(multiSelect.selected[i].id));
+        promises.push(getAlbum({ id: multiSelect.selected[i].id }));
       }
 
       const res = await Promise.all(promises);
@@ -266,7 +266,7 @@ export const GlobalContextMenu = () => {
       notifyToast('info', getPlayedSongsNotification({ ...songs.count, type: 'add' }));
     } else if (misc.contextMenu.type === 'artist') {
       for (let i = 0; i < multiSelect.selected.length; i += 1) {
-        promises.push(getAllArtistSongs(multiSelect.selected[i].id));
+        promises.push(getArtistSongs({ id: multiSelect.selected[i].id }));
       }
 
       const res = await Promise.all(promises);
@@ -298,7 +298,7 @@ export const GlobalContextMenu = () => {
     notifyToast(
       'success',
       `Added ${songCount} song(s) to playlist ${
-        playlists.find((pl: any) => pl.id === playlistId)?.name
+        playlists.find((pl: any) => pl.id === playlistId)?.title
       }`,
       <>
         <StyledButton
@@ -332,7 +332,7 @@ export const GlobalContextMenu = () => {
           });
 
         for (let i = 0; i < folders.length; i += 1) {
-          promises.push(getAllDirectorySongs({ id: multiSelect.selected[i].id }));
+          promises.push(getDirectorySongs({ id: multiSelect.selected[i].id }));
         }
 
         const folderSongs = await Promise.all(promises);
@@ -363,7 +363,7 @@ export const GlobalContextMenu = () => {
         }
       } else if (misc.contextMenu.type === 'album') {
         for (let i = 0; i < multiSelect.selected.length; i += 1) {
-          promises.push(getAlbum(multiSelect.selected[i].id));
+          promises.push(getAlbum({ id: multiSelect.selected[i].id }));
         }
 
         res = await Promise.all(promises);
@@ -700,7 +700,7 @@ export const GlobalContextMenu = () => {
                       data={playlists}
                       placement="autoVerticalStart"
                       virtualized
-                      labelKey="name"
+                      labelKey="title"
                       valueKey="id"
                       width={200}
                       onChange={(e: any) => setSelectedPlaylistId(e)}

--- a/src/components/shared/ContextMenu.tsx
+++ b/src/components/shared/ContextMenu.tsx
@@ -15,7 +15,7 @@ import {
   getPlaylist,
   deletePlaylist,
   getArtistSongs,
-  getDirectorySongs,
+  getMusicDirectorySongs,
 } from '../../api/api';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import {
@@ -135,7 +135,7 @@ export const GlobalContextMenu = () => {
         });
 
       for (let i = 0; i < folders.length; i += 1) {
-        promises.push(getDirectorySongs({ id: folders[i].id }));
+        promises.push(getMusicDirectorySongs({ id: folders[i].id }));
       }
 
       const res = await Promise.all(promises);
@@ -223,7 +223,7 @@ export const GlobalContextMenu = () => {
         });
 
       for (let i = 0; i < folders.length; i += 1) {
-        promises.push(getDirectorySongs({ id: multiSelect.selected[i].id }));
+        promises.push(getMusicDirectorySongs({ id: multiSelect.selected[i].id }));
       }
 
       const res = await Promise.all(promises);
@@ -332,7 +332,7 @@ export const GlobalContextMenu = () => {
           });
 
         for (let i = 0; i < folders.length; i += 1) {
-          promises.push(getDirectorySongs({ id: multiSelect.selected[i].id }));
+          promises.push(getMusicDirectorySongs({ id: multiSelect.selected[i].id }));
         }
 
         const folderSongs = await Promise.all(promises);
@@ -340,7 +340,7 @@ export const GlobalContextMenu = () => {
         folderSongs.push(_.orderBy(music, 'rowIndex', 'asc'));
         songs = _.flatten(folderSongs);
 
-        res = await updatePlaylistSongsLg(localSelectedPlaylistId, songs);
+        res = await updatePlaylistSongsLg({ id: localSelectedPlaylistId, entry: songs });
 
         if (isFailedResponse(res)) {
           notifyToast('error', errorMessages(res)[0]);
@@ -354,7 +354,7 @@ export const GlobalContextMenu = () => {
 
         res = await Promise.all(promises);
         songs = _.flatten(_.map(res, 'song'));
-        res = await updatePlaylistSongsLg(localSelectedPlaylistId, songs);
+        res = await updatePlaylistSongsLg({ id: localSelectedPlaylistId, entry: songs });
 
         if (isFailedResponse(res)) {
           notifyToast('error', errorMessages(res)[0]);
@@ -368,7 +368,7 @@ export const GlobalContextMenu = () => {
 
         res = await Promise.all(promises);
         songs = _.flatten(_.map(res, 'song'));
-        res = await updatePlaylistSongsLg(localSelectedPlaylistId, songs);
+        res = await updatePlaylistSongsLg({ id: localSelectedPlaylistId, entry: songs });
 
         if (isFailedResponse(res)) {
           notifyToast('error', errorMessages(res)[0]);
@@ -394,7 +394,7 @@ export const GlobalContextMenu = () => {
     const res = [];
     for (let i = 0; i < multiSelect.selected.length; i += 1) {
       try {
-        res.push(await deletePlaylist(multiSelect.selected[i].id));
+        res.push(await deletePlaylist({ id: multiSelect.selected[i].id }));
       } catch (err) {
         notifyToast('error', err);
       }
@@ -413,7 +413,7 @@ export const GlobalContextMenu = () => {
 
   const handleCreatePlaylist = async () => {
     try {
-      const res = await createPlaylist(newPlaylistName);
+      const res = await createPlaylist({ name: newPlaylistName });
 
       if (isFailedResponse(res)) {
         notifyToast('error', errorMessages(res)[0]);
@@ -453,7 +453,7 @@ export const GlobalContextMenu = () => {
     const ids = _.map(sortedEntries, 'id');
 
     try {
-      const res = await batchStar(ids, sortedEntries[0].type);
+      const res = await batchStar({ ids, type: sortedEntries[0].type });
 
       if (isFailedResponse(res)) {
         notifyToast('error', errorMessages(res)[0]);
@@ -476,7 +476,7 @@ export const GlobalContextMenu = () => {
 
     try {
       // Infer the type from the first selected entry
-      const res = await batchUnstar(ids, multiSelect.selected[0].type);
+      const res = await batchUnstar({ ids, type: multiSelect.selected[0].type });
 
       if (isFailedResponse(res)) {
         notifyToast('error', errorMessages(res)[0]);

--- a/src/components/shared/ContextMenu.tsx
+++ b/src/components/shared/ContextMenu.tsx
@@ -5,18 +5,6 @@ import { nanoid } from 'nanoid/non-secure';
 import { useQuery, useQueryClient } from 'react-query';
 import { useHistory } from 'react-router';
 import { Col, FlexboxGrid, Form, Grid, Icon, Row, Whisper } from 'rsuite';
-import {
-  getPlaylists,
-  updatePlaylistSongsLg,
-  createPlaylist,
-  batchStar,
-  batchUnstar,
-  getAlbum,
-  getPlaylist,
-  deletePlaylist,
-  getArtistSongs,
-  getMusicDirectorySongs,
-} from '../../api/api';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import {
   addModalPage,
@@ -67,6 +55,7 @@ import {
   isFailedResponse,
 } from '../../shared/utils';
 import { setStatus } from '../../redux/playerSlice';
+import { apiController } from '../../api/controller';
 
 export const ContextMenuButton = ({ text, hotkey, children, ...rest }: any) => {
   return (
@@ -120,7 +109,9 @@ export const GlobalContextMenu = () => {
   const [indexToMoveTo, setIndexToMoveTo] = useState(0);
   const playlistPickerContainerRef = useRef(null);
 
-  const { data: playlists }: any = useQuery(['playlists'], () => getPlaylists());
+  const { data: playlists }: any = useQuery(['playlists'], () =>
+    apiController({ serverType: config.serverType, endpoint: 'getPlaylists' })
+  );
 
   const handlePlay = async () => {
     dispatch(setContextMenu({ show: false }));
@@ -135,7 +126,13 @@ export const GlobalContextMenu = () => {
         });
 
       for (let i = 0; i < folders.length; i += 1) {
-        promises.push(getMusicDirectorySongs({ id: folders[i].id }));
+        promises.push(
+          apiController({
+            serverType: config.serverType,
+            endpoint: 'getMusicDirectorySongs',
+            args: { id: folders[i].id },
+          })
+        );
       }
 
       const res = await Promise.all(promises);
@@ -154,7 +151,13 @@ export const GlobalContextMenu = () => {
       notifyToast('info', getPlayedSongsNotification({ ...songs.count, type: 'play' }));
     } else if (misc.contextMenu.type === 'playlist') {
       for (let i = 0; i < multiSelect.selected.length; i += 1) {
-        promises.push(getPlaylist(multiSelect.selected[i].id));
+        promises.push(
+          apiController({
+            serverType: config.serverType,
+            endpoint: 'getPlaylist',
+            args: { id: multiSelect.selected[i].id },
+          })
+        );
       }
 
       const res = await Promise.all(promises);
@@ -172,7 +175,13 @@ export const GlobalContextMenu = () => {
       notifyToast('info', getPlayedSongsNotification({ ...songs.count, type: 'play' }));
     } else if (misc.contextMenu.type === 'album') {
       for (let i = 0; i < multiSelect.selected.length; i += 1) {
-        promises.push(getAlbum({ id: multiSelect.selected[i].id }));
+        promises.push(
+          apiController({
+            serverType: config.serverType,
+            endpoint: 'getAlbum',
+            args: { id: multiSelect.selected[i].id },
+          })
+        );
       }
 
       const res = await Promise.all(promises);
@@ -191,7 +200,13 @@ export const GlobalContextMenu = () => {
       notifyToast('info', getPlayedSongsNotification({ ...songs.count, type: 'play' }));
     } else if (misc.contextMenu.type === 'artist') {
       for (let i = 0; i < multiSelect.selected.length; i += 1) {
-        promises.push(getArtistSongs({ id: multiSelect.selected[i].id }));
+        promises.push(
+          apiController({
+            serverType: config.serverType,
+            endpoint: 'getArtistSongs',
+            args: { id: multiSelect.selected[i].id },
+          })
+        );
       }
 
       const res = await Promise.all(promises);
@@ -223,7 +238,13 @@ export const GlobalContextMenu = () => {
         });
 
       for (let i = 0; i < folders.length; i += 1) {
-        promises.push(getMusicDirectorySongs({ id: multiSelect.selected[i].id }));
+        promises.push(
+          apiController({
+            serverType: config.serverType,
+            endpoint: 'getMusicDirectorySongs',
+            args: { id: folders[i].id },
+          })
+        );
       }
 
       const res = await Promise.all(promises);
@@ -238,7 +259,13 @@ export const GlobalContextMenu = () => {
       notifyToast('info', getPlayedSongsNotification({ ...songs.count, type: 'add' }));
     } else if (misc.contextMenu.type === 'playlist') {
       for (let i = 0; i < multiSelect.selected.length; i += 1) {
-        promises.push(getPlaylist(multiSelect.selected[i].id));
+        promises.push(
+          apiController({
+            serverType: config.serverType,
+            endpoint: 'getPlaylist',
+            args: { id: multiSelect.selected[i].id },
+          })
+        );
       }
 
       const res = await Promise.all(promises);
@@ -252,7 +279,13 @@ export const GlobalContextMenu = () => {
       notifyToast('info', getPlayedSongsNotification({ ...songs.count, type: 'add' }));
     } else if (misc.contextMenu.type === 'album') {
       for (let i = 0; i < multiSelect.selected.length; i += 1) {
-        promises.push(getAlbum({ id: multiSelect.selected[i].id }));
+        promises.push(
+          apiController({
+            serverType: config.serverType,
+            endpoint: 'getAlbum',
+            args: { id: multiSelect.selected[i].id },
+          })
+        );
       }
 
       const res = await Promise.all(promises);
@@ -266,7 +299,13 @@ export const GlobalContextMenu = () => {
       notifyToast('info', getPlayedSongsNotification({ ...songs.count, type: 'add' }));
     } else if (misc.contextMenu.type === 'artist') {
       for (let i = 0; i < multiSelect.selected.length; i += 1) {
-        promises.push(getArtistSongs({ id: multiSelect.selected[i].id }));
+        promises.push(
+          apiController({
+            serverType: config.serverType,
+            endpoint: 'getArtistSongs',
+            args: { id: multiSelect.selected[i].id },
+          })
+        );
       }
 
       const res = await Promise.all(promises);
@@ -332,7 +371,13 @@ export const GlobalContextMenu = () => {
           });
 
         for (let i = 0; i < folders.length; i += 1) {
-          promises.push(getMusicDirectorySongs({ id: multiSelect.selected[i].id }));
+          promises.push(
+            apiController({
+              serverType: config.serverType,
+              endpoint: 'getMusicDirectorySongs',
+              args: { id: folders[i].id },
+            })
+          );
         }
 
         const folderSongs = await Promise.all(promises);
@@ -340,7 +385,11 @@ export const GlobalContextMenu = () => {
         folderSongs.push(_.orderBy(music, 'rowIndex', 'asc'));
         songs = _.flatten(folderSongs);
 
-        res = await updatePlaylistSongsLg({ id: localSelectedPlaylistId, entry: songs });
+        res = await apiController({
+          serverType: config.serverType,
+          endpoint: 'updatePlaylistSongsLg',
+          args: { id: localSelectedPlaylistId, entry: songs },
+        });
 
         if (isFailedResponse(res)) {
           notifyToast('error', errorMessages(res)[0]);
@@ -349,12 +398,22 @@ export const GlobalContextMenu = () => {
         }
       } else if (misc.contextMenu.type === 'playlist') {
         for (let i = 0; i < multiSelect.selected.length; i += 1) {
-          promises.push(getPlaylist(multiSelect.selected[i].id));
+          promises.push(
+            apiController({
+              serverType: config.serverType,
+              endpoint: 'getPlaylist',
+              args: { id: multiSelect.selected[i].id },
+            })
+          );
         }
 
         res = await Promise.all(promises);
         songs = _.flatten(_.map(res, 'song'));
-        res = await updatePlaylistSongsLg({ id: localSelectedPlaylistId, entry: songs });
+        res = await apiController({
+          serverType: config.serverType,
+          endpoint: 'updatePlaylistSongsLg',
+          args: { id: localSelectedPlaylistId, entry: songs },
+        });
 
         if (isFailedResponse(res)) {
           notifyToast('error', errorMessages(res)[0]);
@@ -363,12 +422,22 @@ export const GlobalContextMenu = () => {
         }
       } else if (misc.contextMenu.type === 'album') {
         for (let i = 0; i < multiSelect.selected.length; i += 1) {
-          promises.push(getAlbum({ id: multiSelect.selected[i].id }));
+          promises.push(
+            apiController({
+              serverType: config.serverType,
+              endpoint: 'getAlbum',
+              args: { id: multiSelect.selected[i].id },
+            })
+          );
         }
 
         res = await Promise.all(promises);
         songs = _.flatten(_.map(res, 'song'));
-        res = await updatePlaylistSongsLg({ id: localSelectedPlaylistId, entry: songs });
+        res = await apiController({
+          serverType: config.serverType,
+          endpoint: 'updatePlaylistSongsLg',
+          args: { id: localSelectedPlaylistId, entry: songs },
+        });
 
         if (isFailedResponse(res)) {
           notifyToast('error', errorMessages(res)[0]);
@@ -394,7 +463,13 @@ export const GlobalContextMenu = () => {
     const res = [];
     for (let i = 0; i < multiSelect.selected.length; i += 1) {
       try {
-        res.push(await deletePlaylist({ id: multiSelect.selected[i].id }));
+        res.push(
+          await apiController({
+            serverType: config.serverType,
+            endpoint: 'deletePlaylist',
+            args: { id: multiSelect.selected[i].id },
+          })
+        );
       } catch (err) {
         notifyToast('error', err);
       }
@@ -413,7 +488,11 @@ export const GlobalContextMenu = () => {
 
   const handleCreatePlaylist = async () => {
     try {
-      const res = await createPlaylist({ name: newPlaylistName });
+      const res = await apiController({
+        serverType: config.serverType,
+        endpoint: 'createPlaylist',
+        args: { name: newPlaylistName },
+      });
 
       if (isFailedResponse(res)) {
         notifyToast('error', errorMessages(res)[0]);
@@ -453,7 +532,11 @@ export const GlobalContextMenu = () => {
     const ids = _.map(sortedEntries, 'id');
 
     try {
-      const res = await batchStar({ ids, type: sortedEntries[0].type });
+      const res = await apiController({
+        serverType: config.serverType,
+        endpoint: 'batchStar',
+        args: { ids, type: sortedEntries[0].type },
+      });
 
       if (isFailedResponse(res)) {
         notifyToast('error', errorMessages(res)[0]);
@@ -476,7 +559,11 @@ export const GlobalContextMenu = () => {
 
     try {
       // Infer the type from the first selected entry
-      const res = await batchUnstar({ ids, type: multiSelect.selected[0].type });
+      const res = await apiController({
+        serverType: config.serverType,
+        endpoint: 'batchUnstar',
+        args: { ids, type: multiSelect.selected[0].type },
+      });
 
       if (isFailedResponse(res)) {
         notifyToast('error', errorMessages(res)[0]);

--- a/src/components/starred/StarredView.tsx
+++ b/src/components/starred/StarredView.tsx
@@ -50,10 +50,10 @@ const StarredView = () => {
       ? data?.album
       : data?.artist,
     favorite.active.tab === 'tracks'
-      ? ['title', 'artist', 'album', 'name', 'genre']
+      ? ['title', 'artist', 'album', 'genre']
       : favorite.active.tab === 'albums'
-      ? ['name', 'artist', 'genre', 'year']
-      : ['name']
+      ? ['title', 'artist', 'genre', 'year']
+      : ['title']
   );
 
   let timeout: any = null;
@@ -230,7 +230,7 @@ const StarredView = () => {
                   data={misc.searchQuery !== '' ? filteredData : data.album}
                   cardTitle={{
                     prefix: '/library/album',
-                    property: 'name',
+                    property: 'title',
                     urlProperty: 'albumId',
                   }}
                   cardSubtitle={{
@@ -279,7 +279,7 @@ const StarredView = () => {
                   data={misc.searchQuery !== '' ? filteredData : data.artist}
                   cardTitle={{
                     prefix: '/library/artist',
-                    property: 'name',
+                    property: 'title',
                     urlProperty: 'id',
                   }}
                   cardSubtitle={{

--- a/src/components/starred/StarredView.tsx
+++ b/src/components/starred/StarredView.tsx
@@ -12,7 +12,6 @@ import {
   toggleRangeSelected,
   setRangeSelected,
 } from '../../redux/multiSelectSlice';
-import { getStarred, unstar } from '../../api/api';
 import GenericPage from '../layout/GenericPage';
 import GenericPageHeader from '../layout/GenericPageHeader';
 import PageLoader from '../loader/PageLoader';
@@ -21,6 +20,8 @@ import GridViewType from '../viewtypes/GridViewType';
 import { setStatus } from '../../redux/playerSlice';
 import { StyledNavItem } from '../shared/styled';
 import { setActive } from '../../redux/favoriteSlice';
+import { apiController } from '../../api/controller';
+import { Server } from '../../types';
 
 const StarredView = () => {
   const history = useHistory();
@@ -40,8 +41,13 @@ const StarredView = () => {
   }, [folder]);
 
   const { isLoading, isError, data, error }: any = useQuery(['starred', musicFolder], () =>
-    getStarred({ musicFolderId: musicFolder })
+    apiController({
+      serverType: config.serverType,
+      endpoint: 'getStarred',
+      args: config.serverType === Server.Subsonic ? { musicFolderId: musicFolder } : null,
+    })
   );
+
   const filteredData = useSearchQuery(
     misc.searchQuery,
     favorite.active.tab === 'tracks'
@@ -97,7 +103,11 @@ const StarredView = () => {
   };
 
   const handleRowFavorite = async (rowData: any) => {
-    await unstar({ id: rowData.id, type: 'music' });
+    await apiController({
+      serverType: config.serverType,
+      endpoint: 'unstar',
+      args: config.serverType === Server.Subsonic ? { id: rowData.id, type: 'music' } : null,
+    });
     dispatch(setStar({ id: [rowData.id], type: 'unstar' }));
     await queryClient.refetchQueries(['starred', musicFolder], {
       active: true,
@@ -105,14 +115,22 @@ const StarredView = () => {
   };
 
   const handleRowFavoriteAlbum = async (rowData: any) => {
-    await unstar({ id: rowData.id, type: 'album' });
+    await apiController({
+      serverType: config.serverType,
+      endpoint: 'unstar',
+      args: config.serverType === Server.Subsonic ? { id: rowData.id, type: 'album' } : null,
+    });
     await queryClient.refetchQueries(['starred', musicFolder], {
       active: true,
     });
   };
 
   const handleRowFavoriteArtist = async (rowData: any) => {
-    await unstar({ id: rowData.id, type: 'artist' });
+    await apiController({
+      serverType: config.serverType,
+      endpoint: 'unstar',
+      args: config.serverType === Server.Subsonic ? { id: rowData.id, type: 'artist' } : null,
+    });
     await queryClient.refetchQueries(['starred', musicFolder], {
       active: true,
     });
@@ -170,9 +188,8 @@ const StarredView = () => {
         />
       }
     >
-      {isLoading ? (
-        <PageLoader />
-      ) : (
+      {(isLoading || !data) && <PageLoader />}
+      {data && (
         <>
           {favorite.active.tab === 'tracks' && (
             <ListViewType

--- a/src/components/starred/StarredView.tsx
+++ b/src/components/starred/StarredView.tsx
@@ -97,7 +97,7 @@ const StarredView = () => {
   };
 
   const handleRowFavorite = async (rowData: any) => {
-    await unstar(rowData.id, 'music');
+    await unstar({ id: rowData.id, type: 'music' });
     dispatch(setStar({ id: [rowData.id], type: 'unstar' }));
     await queryClient.refetchQueries(['starred', musicFolder], {
       active: true,
@@ -105,14 +105,14 @@ const StarredView = () => {
   };
 
   const handleRowFavoriteAlbum = async (rowData: any) => {
-    await unstar(rowData.id, 'album');
+    await unstar({ id: rowData.id, type: 'album' });
     await queryClient.refetchQueries(['starred', musicFolder], {
       active: true,
     });
   };
 
   const handleRowFavoriteArtist = async (rowData: any) => {
-    await unstar(rowData.id, 'artist');
+    await unstar({ id: rowData.id, type: 'artist' });
     await queryClient.refetchQueries(['starred', musicFolder], {
       active: true,
     });

--- a/src/redux/configSlice.ts
+++ b/src/redux/configSlice.ts
@@ -3,6 +3,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import settings from 'electron-settings';
 import { mockSettings } from '../shared/mockSettings';
 import { moveSelectedToIndex } from '../shared/utils';
+import { Server } from '../api/types';
 
 const parsedSettings: any = process.env.NODE_ENV === 'test' ? mockSettings : settings.getSync();
 
@@ -41,6 +42,7 @@ export interface ConfigPage {
       alignment: string | 'flex-start' | 'center';
     };
   };
+  serverType: Server;
 }
 
 interface SortColumn {
@@ -126,6 +128,7 @@ const initialState: ConfigPage = {
       alignment: String(parsedSettings.gridAlignment),
     },
   },
+  serverType: parsedSettings.serverType,
 };
 
 const configSlice = createSlice({

--- a/src/redux/configSlice.ts
+++ b/src/redux/configSlice.ts
@@ -3,7 +3,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import settings from 'electron-settings';
 import { mockSettings } from '../shared/mockSettings';
 import { moveSelectedToIndex } from '../shared/utils';
-import { Server } from '../api/types';
+import { Server } from '../types';
 
 const parsedSettings: any = process.env.NODE_ENV === 'test' ? mockSettings : settings.getSync();
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -112,14 +112,8 @@ const formatBytes = (bytes: number, decimals = 2) => {
 export const formatSongDuration = (duration: number) => {
   const hours = Math.floor(duration / 60 / 60);
   const minutes = Math.floor((duration / 60) % 60);
-  const seconds = String(duration % 60).padStart(2, '0');
+  const seconds = String(Math.trunc(Number(duration % 60))).padStart(2, '0');
 
-  // if (minutes > 60) {
-  //   const hours = Math.floor(minutes / 60);
-  //   const newMinutes = Math.floor(minutes % 60);
-  //   const newSeconds = String(duration % 60).padStart(2, '0');
-  //   return `${hours}:${newMinutes}:${newSeconds}`;
-  // }
   if (hours > 0) {
     return `${hours}:${String(minutes).padStart(2, '0')}:${seconds}`;
   }
@@ -134,7 +128,7 @@ export const formatSongDuration = (duration: number) => {
 export const formatDuration = (duration: number) => {
   const hours = Math.floor(duration / 60 / 60);
   const minutes = Math.floor((duration / 60) % 60);
-  const seconds = String(duration % 60).padStart(2, '0');
+  const seconds = String(Math.trunc(Number(duration % 60))).padStart(2, '0');
 
   if (hours > 0) {
     return `${hours} hr ${minutes} min ${seconds} sec`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,44 @@ export enum Item {
 }
 
 export type ServerType = Server.Subsonic | Server.Jellyfin;
-export type APIEndpoints = 'getPlaylist' | 'getPlaylists';
+
+export type APIEndpoints =
+  | 'getPlaylist'
+  | 'getPlaylists'
+  | 'getStarred'
+  | 'getAlbum'
+  | 'getAlbums'
+  | 'getRandomSongs'
+  | 'getArtist'
+  | 'getArtists'
+  | 'getArtistInfo'
+  | 'getArtistSongs'
+  | 'startScan'
+  | 'getScanStatus'
+  | 'star'
+  | 'unstar'
+  | 'batchStar'
+  | 'batchUnstar'
+  | 'setRating'
+  | 'getSimilarSongs'
+  | 'updatePlaylistSongs'
+  | 'updatePlaylistSongsLg'
+  | 'deletePlaylist'
+  | 'createPlaylist'
+  | 'updatePlaylist'
+  | 'updatePlaylistSongsLg'
+  | 'deletePlaylist'
+  | 'createPlaylist'
+  | 'updatePlaylist'
+  | 'clearPlaylist'
+  | 'getGenres'
+  | 'getSearch'
+  | 'scrobble'
+  | 'getIndexes'
+  | 'getMusicFolders'
+  | 'getMusicDirectory'
+  | 'getMusicDirectorySongs'
+  | 'getDownloadUrl';
 
 export interface Album {
   id: string;


### PR DESCRIPTION
- Adds normalization/types for endpoint returns
- Adds API controller between multiple APIs (Subsonic & Jellyfin)
- Changes all page endpoints to use the controller

- Basic jellyfin support (only Playlist browse/play)