### PR TITLE
Fix scrobble finish condition for jellyfin (#111)

### DIFF
--- a/src/api/jellyfinApi.ts
+++ b/src/api/jellyfinApi.ts
@@ -635,6 +635,7 @@ export const scrobble = async (options: {
     jellyfinApi.post(`/sessions/playing/stopped`, {
       ItemId: options.id,
       IsPaused: true,
+      PositionTicks: options.position && Math.round(options.position),
     });
 
     return jellyfinApi.post(`/users/${auth.username}/playeditems/${options.id}`, null, {


### PR DESCRIPTION
Closes #111 

This sends the `PositionTicks` value to the `/sessions/playing/stopped` endpoint so that [jellyfin-plugin-lastfm](https://github.com/jesseward/jellyfin-plugin-lastfm) knows to send the scrobble to lastfm.