### PR TITLE
Volume handler improvements (player bar)

### DIFF
--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -238,7 +238,7 @@ const listenHandler = (
   }
 };
 
-const Player = ({ currentEntryList, children }: any, ref: any) => {
+const Player = ({ currentEntryList, muted, children }: any, ref: any) => {
   const dispatch = useAppDispatch();
   const player1Ref = useRef<any>();
   const player2Ref = useRef<any>();
@@ -634,6 +634,7 @@ const Player = ({ currentEntryList, children }: any, ref: any) => {
             player1Ref.current.audioEl.current.src = getSrc1();
           }
         }}
+        muted={muted}
         crossOrigin="anonymous"
       />
       <ReactAudioPlayer
@@ -657,6 +658,7 @@ const Player = ({ currentEntryList, children }: any, ref: any) => {
             player2Ref.current.audioEl.current.src = getSrc2();
           }
         }}
+        muted={muted}
         crossOrigin="anonymous"
       />
       {children}

--- a/src/components/player/PlayerBar.tsx
+++ b/src/components/player/PlayerBar.tsx
@@ -150,6 +150,23 @@ const PlayerBar = () => {
     }
   };
 
+  const handleVolumeWheel = (e: any) => {
+    if (e.deltaY > 0) {
+      if (!isDraggingVolume) {
+        setIsDraggingVolume(true);
+      }
+      let vol = Number((playQueue.volume - 0.01).toFixed(2));
+      vol = vol < 0 ? 0 : vol;
+      setLocalVolume(vol);
+      dispatch(setVolume(vol));
+    } else {
+      let vol = Number((playQueue.volume + 0.01).toFixed(2));
+      vol = vol > 1 ? 1 : vol;
+      setLocalVolume(vol);
+      dispatch(setVolume(vol));
+    }
+  };
+
   const handleClickForward = () => {
     if (playQueue[currentEntryList].length > 0) {
       const seekForwardInterval = Number(settings.getSync('seekForwardInterval'));
@@ -691,18 +708,30 @@ const PlayerBar = () => {
                     }
                     onClick={() => setMuted(!muted)}
                     size="lg"
-                    style={{ cursor: 'pointer', marginRight: '15px', padding: '0' }}
                   />
-                  <CustomSlider
-                    tabIndex={0}
-                    progress
-                    value={Math.floor(localVolume * 100)}
-                    $isDragging={isDraggingVolume}
-                    tooltip={false}
-                    style={{ width: '100px', marginRight: '10px' }}
-                    onChange={handleVolumeSlider}
-                    onKeyDown={handleVolumeKey}
-                  />
+                  <Whisper
+                    trigger="hover"
+                    placement="top"
+                    delay={200}
+                    preventOverflow
+                    speaker={
+                      <StyledPopover>
+                        {muted ? 'Muted' : Math.floor(localVolume * 100)}
+                      </StyledPopover>
+                    }
+                  >
+                    <CustomSlider
+                      tabIndex={0}
+                      progress
+                      value={Math.floor(localVolume * 100)}
+                      $isDragging={isDraggingVolume}
+                      tooltip={false}
+                      style={{ width: '100px', marginRight: '10px' }}
+                      onChange={handleVolumeSlider}
+                      onKeyDown={handleVolumeKey}
+                      onWheel={handleVolumeWheel}
+                    />
+                  </Whisper>
                 </Row>
               </Grid>
             </PlayerColumn>

--- a/src/components/player/PlayerBar.tsx
+++ b/src/components/player/PlayerBar.tsx
@@ -48,6 +48,7 @@ const PlayerBar = () => {
   const [manualSeek, setManualSeek] = useState(0);
   const [currentEntryList, setCurrentEntryList] = useState('entry');
   const [localVolume, setLocalVolume] = useState(Number(settings.getSync('volume')));
+  const [muted, setMuted] = useState(false);
   const playersRef = useRef<any>();
   const history = useHistory();
 
@@ -278,7 +279,7 @@ const PlayerBar = () => {
   };
 
   return (
-    <Player ref={playersRef} currentEntryList={currentEntryList}>
+    <Player ref={playersRef} currentEntryList={currentEntryList} muted={muted}>
       {playQueue.showDebugWindow && <DebugWindow currentEntryList={currentEntryList} />}
       <PlayerContainer>
         <FlexboxGrid align="middle" style={{ height: '100%' }}>
@@ -686,14 +687,11 @@ const PlayerBar = () => {
                   {/* Volume Slider */}
                   <VolumeIcon
                     icon={
-                      playQueue.volume > 0.7
-                        ? 'volume-up'
-                        : playQueue.volume === 0
-                        ? 'volume-off'
-                        : 'volume-down'
+                      muted ? 'volume-off' : playQueue.volume > 0.7 ? 'volume-up' : 'volume-down'
                     }
+                    onClick={() => setMuted(!muted)}
                     size="lg"
-                    style={{ marginRight: '15px', padding: '0' }}
+                    style={{ cursor: 'pointer', marginRight: '15px', padding: '0' }}
                   />
                   <CustomSlider
                     tabIndex={0}

--- a/src/components/player/styled.tsx
+++ b/src/components/player/styled.tsx
@@ -114,6 +114,9 @@ export const DurationSpan = styled.span`
 
 export const VolumeIcon = styled(Icon)`
   color: ${(props) => props.theme.colors.layout.playerBar.color};
+  cursor: pointer;
+  margin-right: 15px;
+  padding: 0;
 `;
 
 export const MiniViewContainer = styled.div<{ display: string }>`


### PR DESCRIPTION
Closes #112 

- Add volume mute/unmute click on the volume icon
![image](https://user-images.githubusercontent.com/42182408/144201964-1db5b075-2aac-4cba-9c55-7d75d568cfc0.png)

- Add tooltip on volume slider hover
![image](https://user-images.githubusercontent.com/42182408/144202041-42c62f45-07d6-4fb7-95cf-09350e840666.png)

- Add volume control using mouse wheel up/down