### PR TITLE
Fix album artist sort

### DIFF
--- a/src/api/jellyfinApi.ts
+++ b/src/api/jellyfinApi.ts
@@ -345,7 +345,7 @@ export const getAlbums = async (options: {
 }) => {
   const sortTypes = [
     { original: 'alphabeticalByName', replacement: 'SortName', sortOrder: 'Ascending' },
-    { original: 'alphabeticalByArtist', replacement: 'Artist', sortOrder: 'Ascending' },
+    { original: 'alphabeticalByArtist', replacement: 'AlbumArtist', sortOrder: 'Ascending' },
     { original: 'frequent', replacement: 'PlayCount', sortOrder: 'Ascending' },
     { original: 'random', replacement: 'Random', sortOrder: 'Ascending' },
     { original: 'newest', replacement: 'DateCreated', sortOrder: 'Descending' },


### PR DESCRIPTION
Closes #115 

Changes sort from `Artist` to `AlbumArtist` when using the `A-Z (Artist)` filter in the album list.

![image](https://user-images.githubusercontent.com/42182408/144209366-8b5003d6-e6c6-4ff8-933d-d409f39a1077.png)