### PR TITLE
Advanced album filtering

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -14,6 +14,7 @@ import { FavoritePage } from '../redux/favoriteSlice';
 import App from '../App';
 import { AlbumPage } from '../redux/albumSlice';
 import { Server } from '../types';
+import { ArtistPage } from '../redux/artistSlice';
 
 const middlewares: Middleware<Record<string, unknown>, any, Dispatch<AnyAction>>[] | undefined = [];
 const mockStore = configureMockStore(middlewares);
@@ -89,6 +90,18 @@ const miscState: General = {
 };
 
 const playlistState: Playlist = {
+  active: {
+    list: {
+      sort: {
+        type: 'asc',
+      },
+    },
+    page: {
+      sort: {
+        type: 'asc',
+      },
+    },
+  },
   entry: [],
   sortedEntry: [],
 };
@@ -376,12 +389,59 @@ const configState: ConfigPage = {
 const favoriteState: FavoritePage = {
   active: {
     tab: 'tracks',
+    album: {
+      sort: {
+        type: 'asc',
+      },
+    },
+    artist: {
+      sort: {
+        type: 'asc',
+      },
+    },
   },
 };
 
 const albumState: AlbumPage = {
   active: {
     filter: 'random',
+  },
+  advancedFilters: {
+    enabled: false,
+    nav: 'filters',
+    properties: {
+      starred: false,
+      genre: {
+        list: [],
+        type: 'and',
+      },
+      artist: {
+        list: [],
+        type: 'and',
+      },
+      year: {
+        from: 0,
+        to: 0,
+      },
+      sort: {
+        type: 'asc',
+      },
+    },
+  },
+};
+
+const artistState: ArtistPage = {
+  active: {
+    list: {
+      sort: {
+        type: 'asc',
+      },
+    },
+    page: {
+      sort: {
+        type: 'asc',
+      },
+    },
   },
 };
 
@@ -394,6 +454,7 @@ const mockInitialState = {
   config: configState,
   favorite: favoriteState,
   album: albumState,
+  artist: artistState,
 };
 
 describe('App', () => {

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -214,7 +214,7 @@ const Layout = ({ footer, children, disableSidebar, font }: any) => {
                       <Nav
                         activeKey={activeConfigNav}
                         onSelect={(e) => setActiveConfigNav(e)}
-                        appearance="subtle"
+                        appearance="tabs"
                       >
                         <StyledNavItem eventKey="listView">List-View</StyledNavItem>
                         <StyledNavItem eventKey="gridView">Grid-View</StyledNavItem>
@@ -224,7 +224,7 @@ const Layout = ({ footer, children, disableSidebar, font }: any) => {
                     </StyledPopover>
                   }
                   trigger="click"
-                  placement="autoVerticalEnd"
+                  placement="bottomEnd"
                   preventOverflow
                 >
                   <StyledIconButton appearance="subtle" icon={<Icon icon="cog" />} />

--- a/src/components/library/AdvancedFilters.tsx
+++ b/src/components/library/AdvancedFilters.tsx
@@ -1,12 +1,11 @@
 import _ from 'lodash';
 import React, { useEffect, useRef, useState } from 'react';
-import { ButtonToolbar, Icon, RadioGroup } from 'rsuite';
+import { ButtonToolbar, RadioGroup } from 'rsuite';
 import styled from 'styled-components';
 import { useAppDispatch } from '../../redux/hooks';
 import {
   StyledCheckbox,
   StyledCheckPicker,
-  StyledIconButton,
   StyledInputPickerContainer,
   StyledRadio,
 } from '../shared/styled';
@@ -189,7 +188,6 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
             labelKey="title"
             valueKey="title"
             virtualized
-            cleanable={false}
             renderMenuItem={(label: string, item: any) => {
               return (
                 <div>
@@ -204,20 +202,6 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
                 setAdvancedFilters({
                   filter: 'genre',
                   value: { ...filter.properties.genre, list: e },
-                })
-              );
-            }}
-          />
-          <StyledIconButton
-            appearance={filter.properties.genre.list.length > 0 ? 'primary' : 'subtle'}
-            disabled={filter.properties.genre.list.length === 0}
-            size="xs"
-            icon={<Icon icon="close" />}
-            onClick={() => {
-              dispatch(
-                setAdvancedFilters({
-                  filter: 'genre',
-                  value: { ...filter.properties.genre, list: [] },
                 })
               );
             }}
@@ -261,7 +245,6 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
             labelKey="title"
             valueKey="id"
             virtualized
-            cleanable={false}
             renderMenuItem={(label: string, item: any) => {
               return (
                 <div>
@@ -276,20 +259,6 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
                 setAdvancedFilters({
                   filter: 'artist',
                   value: { ...filter.properties.artist, list: e },
-                })
-              );
-            }}
-          />
-          <StyledIconButton
-            appearance={filter.properties.artist.list.length > 0 ? 'primary' : 'subtle'}
-            disabled={filter.properties.artist.list.length === 0}
-            size="xs"
-            icon={<Icon icon="close" />}
-            onClick={() => {
-              dispatch(
-                setAdvancedFilters({
-                  filter: 'artist',
-                  value: { ...filter.properties.artist, list: [] },
                 })
               );
             }}

--- a/src/components/library/AdvancedFilters.tsx
+++ b/src/components/library/AdvancedFilters.tsx
@@ -13,7 +13,7 @@ import {
   StyledToggle,
 } from '../shared/styled';
 
-const FilterHeader = styled.div`
+export const FilterHeader = styled.div`
   font-size: 16px;
   font-weight: bold;
   line-height: unset;

--- a/src/components/library/AdvancedFilters.tsx
+++ b/src/components/library/AdvancedFilters.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable react/destructuring-assignment */
 import _ from 'lodash';
 import React, { useEffect, useRef, useState } from 'react';
-import { RadioGroup } from 'rsuite';
+import { ButtonToolbar, Icon, RadioGroup } from 'rsuite';
 import styled from 'styled-components';
 import { useAppDispatch } from '../../redux/hooks';
 import {
   StyledCheckbox,
   StyledCheckPicker,
+  StyledIconButton,
   StyledInputPickerContainer,
   StyledRadio,
 } from '../shared/styled';
@@ -19,18 +20,41 @@ const FilterHeader = styled.h1`
 const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilters }: any) => {
   const dispatch = useAppDispatch();
   const [availableGenres, setAvailableGenres] = useState<any[]>([]);
+  const [availableArtists, setAvailableArtists] = useState<any[]>([]);
+  const [data, setData] = useState<any[]>([]);
   const genreFilterPickerContainerRef = useRef<any>();
+  const artistFilterPickerContainerRef = useRef<any>();
 
   useEffect(() => {
-    const allGenres = _.flatten(
-      _.map(
-        filter.properties.starred || filter.properties.genre.type === 'and'
-          ? filteredData
-          : originalData,
-        'genre'
-      )
-    );
+    if (
+      filter.properties.artist.type === 'or' &&
+      filter.properties.artist.list.length > 0 &&
+      filter.properties.genre.list.length > 0
+    ) {
+      return setData(filteredData.byGenreData);
+    }
 
+    if (filter.properties.artist.type === 'or' && filter.properties.artist.list.length > 0) {
+      return setData(filteredData.byStarredData);
+    }
+
+    if (filter.properties.genre.list.length > 0) {
+      return setData(filteredData.filteredData);
+    }
+
+    return setData(originalData);
+  }, [
+    filter.properties.artist.list.length,
+    filter.properties.artist.type,
+    filter.properties.genre.list.length,
+    filter.properties.genre.type,
+    filter.properties.starred,
+    filteredData,
+    originalData,
+  ]);
+
+  useEffect(() => {
+    const allGenres = _.flatten(_.map(data, 'genre'));
     const counts = _.countBy(allGenres, 'title');
     const uniqueGenres = _.orderBy(_.uniqBy(allGenres, 'title'), [
       (entry: any) => {
@@ -49,9 +73,29 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
         };
       })
     );
-  }, [filter.properties.genre.type, filter.properties.starred, filteredData, originalData]);
+  }, [data, filter.properties.genre.type, filter.properties.starred, filteredData, originalData]);
 
-  console.log(`availableGenres`, availableGenres);
+  useEffect(() => {
+    const allArtists = _.flatten(_.map(data, 'artist'));
+    const counts = _.countBy(allArtists, 'id');
+    const uniqueArtists = _.orderBy(_.uniqBy(allArtists, 'id'), [
+      (entry: any) => {
+        return typeof entry.title === 'string'
+          ? entry.title.toLowerCase() || ''
+          : +entry.title || '';
+      },
+    ]);
+
+    setAvailableArtists(
+      uniqueArtists.map((artist) => {
+        return {
+          id: artist.id,
+          title: artist.title,
+          count: counts[artist.id],
+        };
+      })
+    );
+  }, [data, filter.properties.artist.type, filter.properties.starred, filteredData, originalData]);
 
   return (
     <div>
@@ -94,31 +138,109 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
         <StyledRadio value="or">OR</StyledRadio>
       </RadioGroup>
       <StyledInputPickerContainer ref={genreFilterPickerContainerRef}>
-        <StyledCheckPicker
-          container={() => genreFilterPickerContainerRef.current}
-          data={availableGenres}
-          value={filter.properties.genre.list}
-          labelKey="title"
-          valueKey="title"
-          virtualized
-          renderMenuItem={(label: string, item: any) => {
-            return (
-              <div>
-                {label} ({item.count || 0})
-              </div>
-            );
-          }}
-          sticky
-          style={{ width: '250px' }}
-          onChange={(e: string[]) => {
-            dispatch(
-              setAdvancedFilters({
-                filter: 'genre',
-                value: { ...filter.properties.genre, list: e },
-              })
-            );
-          }}
-        />
+        <ButtonToolbar>
+          <StyledCheckPicker
+            container={() => genreFilterPickerContainerRef.current}
+            data={availableGenres}
+            value={filter.properties.genre.list}
+            labelKey="title"
+            valueKey="title"
+            virtualized
+            cleanable={false}
+            renderMenuItem={(label: string, item: any) => {
+              return (
+                <div>
+                  {label} ({item.count || 0})
+                </div>
+              );
+            }}
+            sticky
+            style={{ width: '250px' }}
+            onChange={(e: string[]) => {
+              dispatch(
+                setAdvancedFilters({
+                  filter: 'genre',
+                  value: { ...filter.properties.genre, list: e },
+                })
+              );
+            }}
+          />
+          <StyledIconButton
+            appearance={filter.properties.genre.list.length > 0 ? 'primary' : ''}
+            disabled={filter.properties.genre.list.length === 0}
+            size="xs"
+            icon={<Icon icon="close" />}
+            onClick={() => {
+              dispatch(
+                setAdvancedFilters({
+                  filter: 'genre',
+                  value: { ...filter.properties.genre, list: [] },
+                })
+              );
+            }}
+          />
+        </ButtonToolbar>
+      </StyledInputPickerContainer>
+      <br />
+      <FilterHeader>Artists</FilterHeader>
+      <RadioGroup
+        inline
+        defaultValue={filter.properties.artist.type}
+        onChange={(e: string) => {
+          dispatch(
+            setAdvancedFilters({
+              filter: 'artist',
+              value: { ...filter.properties.artist, type: e },
+            })
+          );
+        }}
+      >
+        <StyledRadio value="and">AND</StyledRadio>
+        <StyledRadio value="or">OR</StyledRadio>
+      </RadioGroup>
+      <StyledInputPickerContainer ref={artistFilterPickerContainerRef}>
+        <ButtonToolbar>
+          <StyledCheckPicker
+            container={() => artistFilterPickerContainerRef.current}
+            data={availableArtists}
+            value={filter.properties.artist.list}
+            labelKey="title"
+            valueKey="id"
+            virtualized
+            cleanable={false}
+            renderMenuItem={(label: string, item: any) => {
+              return (
+                <div>
+                  {label} ({item.count || 0})
+                </div>
+              );
+            }}
+            sticky
+            style={{ width: '250px' }}
+            onChange={(e: string[]) => {
+              dispatch(
+                setAdvancedFilters({
+                  filter: 'artist',
+                  value: { ...filter.properties.artist, list: e },
+                })
+              );
+            }}
+          />
+          <StyledIconButton
+            appearance={filter.properties.artist.list.length > 0 ? 'primary' : ''}
+            disabled={filter.properties.artist.list.length === 0}
+            size="xs"
+            icon={<Icon icon="close" />}
+            onClick={() => {
+              dispatch(
+                setAdvancedFilters({
+                  filter: 'artist',
+                  value: { ...filter.properties.artist, list: [] },
+                })
+              );
+            }}
+          />
+        </ButtonToolbar>
       </StyledInputPickerContainer>
     </div>
   );

--- a/src/components/library/AdvancedFilters.tsx
+++ b/src/components/library/AdvancedFilters.tsx
@@ -60,7 +60,7 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
         defaultChecked={filter.enabled}
         checked={filter.enabled}
         onChange={(_v: any, e: boolean) => {
-          dispatch(setAdvancedFilters({ ...filter, enabled: e }));
+          dispatch(setAdvancedFilters({ filter: 'enabled', value: e }));
         }}
       >
         Enabled
@@ -71,11 +71,8 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
         onChange={(_v: any, e: boolean) => {
           dispatch(
             setAdvancedFilters({
-              ...filter,
-              properties: {
-                ...filter.properties,
-                starred: e,
-              },
+              filter: 'starred',
+              value: e,
             })
           );
         }}
@@ -89,16 +86,7 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
         defaultValue={filter.properties.genre.type}
         onChange={(e: string) => {
           dispatch(
-            setAdvancedFilters({
-              ...filter,
-              properties: {
-                ...filter.properties,
-                genre: {
-                  ...filter.properties.genre,
-                  type: e,
-                },
-              },
-            })
+            setAdvancedFilters({ filter: 'genre', value: { ...filter.properties.genre, type: e } })
           );
         }}
       >
@@ -125,14 +113,8 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
           onChange={(e: string[]) => {
             dispatch(
               setAdvancedFilters({
-                ...filter,
-                properties: {
-                  ...filter.properties,
-                  genre: {
-                    ...filter.properties.genre,
-                    list: e,
-                  },
-                },
+                filter: 'genre',
+                value: { ...filter.properties.genre, list: e },
               })
             );
           }}

--- a/src/components/library/AdvancedFilters.tsx
+++ b/src/components/library/AdvancedFilters.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/destructuring-assignment */
 import _ from 'lodash';
 import React, { useEffect, useRef, useState } from 'react';
 import { ButtonToolbar, Icon, RadioGroup } from 'rsuite';
@@ -174,7 +173,18 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
         <ButtonToolbar>
           <StyledCheckPicker
             container={() => genreFilterPickerContainerRef.current}
-            data={availableGenres}
+            data={_.concat(
+              availableGenres,
+              _.compact(
+                filter.properties.genre.list.map((genre: any) => {
+                  if (!_.includes(_.map(availableGenres, 'title'), genre)) {
+                    return { title: genre };
+                  }
+
+                  return undefined;
+                })
+              )
+            )}
             value={filter.properties.genre.list}
             labelKey="title"
             valueKey="title"
@@ -235,7 +245,18 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
         <ButtonToolbar>
           <StyledCheckPicker
             container={() => artistFilterPickerContainerRef.current}
-            data={availableArtists}
+            data={_.concat(
+              availableArtists,
+              _.compact(
+                filter.properties.artist.list.map((artistId: any) => {
+                  if (!_.includes(_.map(availableArtists, 'id'), artistId)) {
+                    return { title: artistId, id: artistId };
+                  }
+
+                  return undefined;
+                })
+              )
+            )}
             value={filter.properties.artist.list}
             labelKey="title"
             valueKey="id"

--- a/src/components/library/AdvancedFilters.tsx
+++ b/src/components/library/AdvancedFilters.tsx
@@ -10,6 +10,7 @@ import {
   StyledInputNumber,
   StyledInputPickerContainer,
   StyledRadio,
+  StyledToggle,
 } from '../shared/styled';
 
 const FilterHeader = styled.div`
@@ -134,16 +135,23 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
 
   return (
     <div>
-      <FilterHeader>Filters</FilterHeader>
-      <StyledCheckbox
-        defaultChecked={filter.enabled}
-        checked={filter.enabled}
-        onChange={(_v: any, e: boolean) => {
-          dispatch(setAdvancedFilters({ filter: 'enabled', value: e }));
-        }}
-      >
-        Enabled
-      </StyledCheckbox>
+      <FilterHeader>
+        <FlexboxGrid justify="space-between">
+          <FlexboxGrid.Item>Filters</FlexboxGrid.Item>
+          <FlexboxGrid.Item>
+            <StyledToggle
+              size="md"
+              checkedChildren="On"
+              unCheckedChildren="Off"
+              defaultChecked={filter.enabled}
+              checked={filter.enabled}
+              onChange={(e: boolean) => {
+                dispatch(setAdvancedFilters({ filter: 'enabled', value: e }));
+              }}
+            />
+          </FlexboxGrid.Item>
+        </FlexboxGrid>
+      </FilterHeader>
       <StyledCheckbox
         defaultChecked={filter.properties.starred}
         checked={filter.properties.starred}
@@ -158,7 +166,7 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
       >
         Is favorite
       </StyledCheckbox>
-      <br />
+      <Divider />
       <FilterHeader>Genres</FilterHeader>
       <RadioGroup
         inline
@@ -212,7 +220,7 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
           />
         </ButtonToolbar>
       </StyledInputPickerContainer>
-      <br />
+      <Divider />
       <FilterHeader>Artists</FilterHeader>
       <RadioGroup
         inline
@@ -269,6 +277,7 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
           />
         </ButtonToolbar>
       </StyledInputPickerContainer>
+      <Divider />
       <FilterHeader>
         <FlexboxGrid justify="space-between">
           <FlexboxGrid.Item>Years</FlexboxGrid.Item>

--- a/src/components/library/AdvancedFilters.tsx
+++ b/src/components/library/AdvancedFilters.tsx
@@ -167,7 +167,28 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
         Is favorite
       </StyledCheckbox>
       <Divider />
-      <FilterHeader>Genres</FilterHeader>
+      <FilterHeader>
+        <FlexboxGrid justify="space-between">
+          <FlexboxGrid.Item>Genres</FlexboxGrid.Item>
+          <FlexboxGrid.Item>
+            <StyledButton
+              size="xs"
+              appearance={filter.properties.genre.list.length > 0 ? 'primary' : 'subtle'}
+              disabled={filter.properties.genre.list.length === 0}
+              onClick={() => {
+                dispatch(
+                  setAdvancedFilters({
+                    filter: 'genre',
+                    value: { ...filter.properties.genre, list: [] },
+                  })
+                );
+              }}
+            >
+              Reset
+            </StyledButton>
+          </FlexboxGrid.Item>
+        </FlexboxGrid>
+      </FilterHeader>
       <RadioGroup
         inline
         defaultValue={filter.properties.genre.type}
@@ -200,6 +221,10 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
             labelKey="title"
             valueKey="title"
             virtualized
+            cleanable={false}
+            onEntered={() => {
+              (document.querySelectorAll('.rs-picker-search-bar-input')[0] as HTMLElement).focus();
+            }}
             renderMenuItem={(label: string, item: any) => {
               return (
                 <div>
@@ -221,7 +246,28 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
         </ButtonToolbar>
       </StyledInputPickerContainer>
       <Divider />
-      <FilterHeader>Artists</FilterHeader>
+      <FilterHeader>
+        <FlexboxGrid justify="space-between">
+          <FlexboxGrid.Item>Artists</FlexboxGrid.Item>
+          <FlexboxGrid.Item>
+            <StyledButton
+              size="xs"
+              appearance={filter.properties.artist.list.length > 0 ? 'primary' : 'subtle'}
+              disabled={filter.properties.artist.list.length === 0}
+              onClick={() => {
+                dispatch(
+                  setAdvancedFilters({
+                    filter: 'artist',
+                    value: { ...filter.properties.artist, list: [] },
+                  })
+                );
+              }}
+            >
+              Reset
+            </StyledButton>
+          </FlexboxGrid.Item>
+        </FlexboxGrid>
+      </FilterHeader>
       <RadioGroup
         inline
         defaultValue={filter.properties.artist.type}
@@ -257,6 +303,10 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
             labelKey="title"
             valueKey="id"
             virtualized
+            cleanable={false}
+            onEntered={() => {
+              (document.querySelectorAll('.rs-picker-search-bar-input')[0] as HTMLElement).focus();
+            }}
             renderMenuItem={(label: string, item: any) => {
               return (
                 <div>
@@ -284,7 +334,12 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
           <FlexboxGrid.Item>
             <StyledButton
               size="xs"
-              appearance="primary"
+              appearance={
+                filter.properties.year.from === 0 && filter.properties.year.to === 0
+                  ? 'subtle'
+                  : 'primary'
+              }
+              disabled={filter.properties.year.from === 0 && filter.properties.year.to === 0}
               onClick={() => {
                 dispatch(
                   setAdvancedFilters({

--- a/src/components/library/AdvancedFilters.tsx
+++ b/src/components/library/AdvancedFilters.tsx
@@ -1,0 +1,130 @@
+/* eslint-disable react/destructuring-assignment */
+import _ from 'lodash';
+import React, { useEffect, useRef, useState } from 'react';
+import { RadioGroup } from 'rsuite';
+import styled from 'styled-components';
+import { useAppDispatch } from '../../redux/hooks';
+import {
+  StyledCheckbox,
+  StyledCheckPicker,
+  StyledInputPickerContainer,
+  StyledRadio,
+} from '../shared/styled';
+
+const FilterHeader = styled.h1`
+  font-size: 16px;
+  line-height: unset;
+`;
+
+const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilters }: any) => {
+  const dispatch = useAppDispatch();
+  const [availableGenres, setAvailableGenres] = useState<any[]>([]);
+  const genreFilterPickerContainerRef = useRef<any>();
+
+  useEffect(() => {
+    setAvailableGenres(
+      _.orderBy(
+        _.uniqBy(
+          _.flatten(
+            _.map(
+              filter.properties.starred || filter.properties.genre.type === 'and'
+                ? filteredData
+                : originalData,
+              'genre'
+            )
+          ),
+          'title'
+        ),
+        [
+          (entry: any) => {
+            return typeof entry.title === 'string'
+              ? entry.title.toLowerCase() || ''
+              : +entry.title || '';
+          },
+        ]
+      )
+    );
+  }, [filter.properties.genre.type, filter.properties.starred, filteredData, originalData]);
+
+  return (
+    <div>
+      <FilterHeader>Filters</FilterHeader>
+      <StyledCheckbox
+        defaultChecked={filter.enabled}
+        checked={filter.enabled}
+        onChange={(_v: any, e: boolean) => {
+          dispatch(setAdvancedFilters({ ...filter, enabled: e }));
+        }}
+      >
+        Enabled
+      </StyledCheckbox>
+      <StyledCheckbox
+        defaultChecked={filter.properties.starred}
+        checked={filter.properties.starred}
+        onChange={(_v: any, e: boolean) => {
+          dispatch(
+            setAdvancedFilters({
+              ...filter,
+              properties: {
+                ...filter.properties,
+                starred: e,
+              },
+            })
+          );
+        }}
+      >
+        Is favorite
+      </StyledCheckbox>
+      <br />
+      <FilterHeader>Genres</FilterHeader>
+      <RadioGroup
+        inline
+        defaultValue={filter.properties.genre.type}
+        onChange={(e: string) => {
+          dispatch(
+            setAdvancedFilters({
+              ...filter,
+              properties: {
+                ...filter.properties,
+                genre: {
+                  ...filter.properties.genre,
+                  type: e,
+                },
+              },
+            })
+          );
+        }}
+      >
+        <StyledRadio value="and">AND</StyledRadio>
+        <StyledRadio value="or">OR</StyledRadio>
+      </RadioGroup>
+      <StyledInputPickerContainer ref={genreFilterPickerContainerRef}>
+        <StyledCheckPicker
+          container={() => genreFilterPickerContainerRef.current}
+          data={availableGenres}
+          value={filter.properties.genre.list}
+          labelKey="title"
+          valueKey="title"
+          sticky
+          style={{ width: '250px' }}
+          onChange={(e: string[]) => {
+            dispatch(
+              setAdvancedFilters({
+                ...filter,
+                properties: {
+                  ...filter.properties,
+                  genre: {
+                    ...filter.properties.genre,
+                    list: e,
+                  },
+                },
+              })
+            );
+          }}
+        />
+      </StyledInputPickerContainer>
+    </div>
+  );
+};
+
+export default AdvancedFilters;

--- a/src/components/library/AdvancedFilters.tsx
+++ b/src/components/library/AdvancedFilters.tsx
@@ -1,17 +1,20 @@
 import _ from 'lodash';
 import React, { useEffect, useRef, useState } from 'react';
-import { ButtonToolbar, RadioGroup } from 'rsuite';
+import { ButtonToolbar, ControlLabel, Divider, FlexboxGrid, RadioGroup } from 'rsuite';
 import styled from 'styled-components';
 import { useAppDispatch } from '../../redux/hooks';
 import {
+  StyledButton,
   StyledCheckbox,
   StyledCheckPicker,
+  StyledInputNumber,
   StyledInputPickerContainer,
   StyledRadio,
 } from '../shared/styled';
 
-const FilterHeader = styled.h1`
+const FilterHeader = styled.div`
   font-size: 16px;
+  font-weight: bold;
   line-height: unset;
 `;
 
@@ -28,7 +31,8 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
   // 1. byStarredData
   // 2. byGenreData
   // 3. byArtistData
-  // 4. filteredData
+  // 4. byYearData
+  // 5. filteredData <- Same as previous (byYearData)
 
   useEffect(() => {
     if (filter.properties.artist.type === 'and') {
@@ -265,6 +269,67 @@ const AdvancedFilters = ({ filteredData, originalData, filter, setAdvancedFilter
           />
         </ButtonToolbar>
       </StyledInputPickerContainer>
+      <FilterHeader>
+        <FlexboxGrid justify="space-between">
+          <FlexboxGrid.Item>Years</FlexboxGrid.Item>
+          <FlexboxGrid.Item>
+            <StyledButton
+              size="xs"
+              appearance="primary"
+              onClick={() => {
+                dispatch(
+                  setAdvancedFilters({
+                    filter: 'year',
+                    value: { from: 0, to: 0 },
+                  })
+                );
+              }}
+            >
+              Reset
+            </StyledButton>
+          </FlexboxGrid.Item>
+        </FlexboxGrid>
+      </FilterHeader>
+      <FlexboxGrid justify="space-between">
+        <FlexboxGrid.Item>
+          <ControlLabel>From</ControlLabel>
+          <StyledInputNumber
+            width={100}
+            min={0}
+            max={3000}
+            step={1}
+            defaultValue={filter.properties.year.from}
+            value={filter.properties.year.from}
+            onChange={(e: number) => {
+              dispatch(
+                setAdvancedFilters({
+                  filter: 'year',
+                  value: { ...filter.properties.year, from: Number(e) },
+                })
+              );
+            }}
+          />
+        </FlexboxGrid.Item>
+        <FlexboxGrid.Item>
+          <ControlLabel>To</ControlLabel>
+          <StyledInputNumber
+            width={100}
+            min={0}
+            max={3000}
+            step={1}
+            defaultValue={filter.properties.year.to}
+            value={filter.properties.year.to}
+            onChange={(e: number) => {
+              dispatch(
+                setAdvancedFilters({
+                  filter: 'year',
+                  value: { ...filter.properties.year, to: Number(e) },
+                })
+              );
+            }}
+          />
+        </FlexboxGrid.Item>
+      </FlexboxGrid>
     </div>
   );
 };

--- a/src/components/library/AlbumList.tsx
+++ b/src/components/library/AlbumList.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import _ from 'lodash';
 import settings from 'electron-settings';
-import { ButtonToolbar, Icon, Whisper } from 'rsuite';
+import { ButtonToolbar, Whisper } from 'rsuite';
 import { useQuery, useQueryClient } from 'react-query';
 import { useHistory } from 'react-router-dom';
 import GridViewType from '../viewtypes/GridViewType';
@@ -18,12 +18,12 @@ import {
   clearSelected,
 } from '../../redux/multiSelectSlice';
 import {
-  StyledIconButton,
   StyledInputPicker,
   StyledInputPickerContainer,
   StyledPopover,
+  StyledTag,
 } from '../shared/styled';
-import { RefreshButton } from '../shared/ToolbarButtons';
+import { FilterButton, RefreshButton } from '../shared/ToolbarButtons';
 import { setActive, setAdvancedFilters } from '../../redux/albumSlice';
 import { setSearchQuery } from '../../redux/miscSlice';
 import { apiController } from '../../api/controller';
@@ -229,7 +229,14 @@ const AlbumList = () => {
       hideDivider
       header={
         <GenericPageHeader
-          title="Albums"
+          title={
+            <>
+              Albums{' '}
+              <StyledTag style={{ verticalAlign: 'middle', cursor: 'default' }}>
+                {filteredData?.length || '...'}
+              </StyledTag>
+            </>
+          }
           subtitle={
             <StyledInputPickerContainer ref={albumFilterPickerContainerRef}>
               <ButtonToolbar>
@@ -257,41 +264,43 @@ const AlbumList = () => {
                     setIsRefresh(false);
                   }}
                 />
-                <Whisper
-                  trigger="click"
-                  enterable
-                  placement="bottom"
-                  speaker={
-                    <StyledPopover width="275px" opacity={0.97}>
-                      <AdvancedFilters
-                        filteredData={{
-                          filteredData,
-                          byArtistData,
-                          byArtistBaseData,
-                          byGenreData,
-                          byStarredData,
-                          byYearData,
-                        }}
-                        originalData={albums}
-                        filter={album.advancedFilters}
-                        setAdvancedFilters={setAdvancedFilters}
-                      />
-                    </StyledPopover>
-                  }
-                >
-                  <StyledIconButton size="sm" icon={<Icon icon="filter" />} />
-                </Whisper>
-                <RefreshButton
-                  onClick={handleRefresh}
-                  size="sm"
-                  loading={isRefreshing}
-                  width={100}
-                />{' '}
-                {filteredData?.length}
+                <RefreshButton onClick={handleRefresh} size="sm" loading={isRefreshing} />
               </ButtonToolbar>
             </StyledInputPickerContainer>
           }
           subsidetitle={<></>}
+          sidetitle={
+            <>
+              <Whisper
+                trigger="click"
+                enterable
+                placement="bottomEnd"
+                preventOverflow
+                speaker={
+                  <StyledPopover width="275px" opacity={0.97}>
+                    <AdvancedFilters
+                      filteredData={{
+                        filteredData,
+                        byArtistData,
+                        byArtistBaseData,
+                        byGenreData,
+                        byStarredData,
+                        byYearData,
+                      }}
+                      originalData={albums}
+                      filter={album.advancedFilters}
+                      setAdvancedFilters={setAdvancedFilters}
+                    />
+                  </StyledPopover>
+                }
+              >
+                <FilterButton
+                  size="sm"
+                  appearance={album.advancedFilters.enabled ? 'primary' : 'subtle'}
+                />
+              </Whisper>
+            </>
+          }
           showViewTypeButtons
           viewTypeSetting="album"
           handleListClick={() => setViewType('list')}

--- a/src/components/library/AlbumList.tsx
+++ b/src/components/library/AlbumList.tsx
@@ -132,7 +132,10 @@ const AlbumList = () => {
     'year',
   ]);
 
-  const filteredData = useAdvancedFilter(albums, album.advancedFilters);
+  const { filteredData, byArtistData, byGenreData, byStarredData } = useAdvancedFilter(
+    albums,
+    album.advancedFilters
+  );
 
   useEffect(() => {
     setSortTypes(_.compact(_.concat(ALBUM_SORT_TYPES, genres)));
@@ -257,7 +260,7 @@ const AlbumList = () => {
                   speaker={
                     <StyledPopover width="400px">
                       <AdvancedFilters
-                        filteredData={filteredData}
+                        filteredData={{ filteredData, byArtistData, byGenreData, byStarredData }}
                         originalData={albums}
                         filter={album.advancedFilters}
                         setAdvancedFilters={setAdvancedFilters}

--- a/src/components/library/AlbumList.tsx
+++ b/src/components/library/AlbumList.tsx
@@ -132,10 +132,13 @@ const AlbumList = () => {
     'year',
   ]);
 
-  const { filteredData, byArtistData, byGenreData, byStarredData } = useAdvancedFilter(
-    albums,
-    album.advancedFilters
-  );
+  const {
+    filteredData,
+    byArtistData,
+    byArtistBaseData,
+    byGenreData,
+    byStarredData,
+  } = useAdvancedFilter(albums, album.advancedFilters);
 
   useEffect(() => {
     setSortTypes(_.compact(_.concat(ALBUM_SORT_TYPES, genres)));
@@ -260,7 +263,13 @@ const AlbumList = () => {
                   speaker={
                     <StyledPopover width="400px">
                       <AdvancedFilters
-                        filteredData={{ filteredData, byArtistData, byGenreData, byStarredData }}
+                        filteredData={{
+                          filteredData,
+                          byArtistData,
+                          byArtistBaseData,
+                          byGenreData,
+                          byStarredData,
+                        }}
                         originalData={albums}
                         filter={album.advancedFilters}
                         setAdvancedFilters={setAdvancedFilters}

--- a/src/components/library/AlbumList.tsx
+++ b/src/components/library/AlbumList.tsx
@@ -261,7 +261,7 @@ const AlbumList = () => {
                   enterable
                   placement="bottom"
                   speaker={
-                    <StyledPopover width="400px">
+                    <StyledPopover width="300px">
                       <AdvancedFilters
                         filteredData={{
                           filteredData,

--- a/src/components/library/AlbumList.tsx
+++ b/src/components/library/AlbumList.tsx
@@ -138,6 +138,7 @@ const AlbumList = () => {
     byArtistBaseData,
     byGenreData,
     byStarredData,
+    byYearData,
   } = useAdvancedFilter(albums, album.advancedFilters);
 
   useEffect(() => {
@@ -261,7 +262,7 @@ const AlbumList = () => {
                   enterable
                   placement="bottom"
                   speaker={
-                    <StyledPopover width="300px">
+                    <StyledPopover width="275px" opacity={0.97}>
                       <AdvancedFilters
                         filteredData={{
                           filteredData,
@@ -269,6 +270,7 @@ const AlbumList = () => {
                           byArtistBaseData,
                           byGenreData,
                           byStarredData,
+                          byYearData,
                         }}
                         originalData={albums}
                         filter={album.advancedFilters}

--- a/src/components/library/GenreList.tsx
+++ b/src/components/library/GenreList.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../redux/multiSelectSlice';
 import { setActive } from '../../redux/albumSlice';
 import { apiController } from '../../api/controller';
+import { StyledTag } from '../shared/styled';
 
 const GenreList = () => {
   const dispatch = useAppDispatch();
@@ -65,7 +66,21 @@ const GenreList = () => {
   };
 
   return (
-    <GenericPage hideDivider header={<GenericPageHeader title="Genres" />}>
+    <GenericPage
+      hideDivider
+      header={
+        <GenericPageHeader
+          title={
+            <>
+              Genres{' '}
+              <StyledTag style={{ verticalAlign: 'middle', cursor: 'default' }}>
+                {genres?.length || '...'}
+              </StyledTag>
+            </>
+          }
+        />
+      }
+    >
       {isLoading && <PageLoader />}
       {isError && <div>Error: {error}</div>}
       {!isLoading && genres && !isError && (

--- a/src/components/player/NowPlayingMiniView.tsx
+++ b/src/components/player/NowPlayingMiniView.tsx
@@ -37,6 +37,7 @@ import {
   StyledInputPicker,
   StyledInputPickerContainer,
   StyledPopover,
+  StyledTag,
 } from '../shared/styled';
 import { MiniViewContainer } from './styled';
 import {
@@ -466,6 +467,9 @@ const NowPlayingMiniView = () => {
                           }
                         }}
                       />
+                      <StyledTag style={{ verticalAlign: 'middle', cursor: 'default' }}>
+                        {playQueue.entry?.length || '...'}
+                      </StyledTag>
                     </ButtonToolbar>
                   </FlexboxGrid.Item>
                   <FlexboxGrid.Item>

--- a/src/components/player/NowPlayingView.tsx
+++ b/src/components/player/NowPlayingView.tsx
@@ -49,6 +49,7 @@ import {
   StyledInputPicker,
   StyledInputPickerContainer,
   StyledPopover,
+  StyledTag,
 } from '../shared/styled';
 import {
   errorMessages,
@@ -303,7 +304,14 @@ const NowPlayingView = () => {
       hideDivider
       header={
         <GenericPageHeader
-          title="Now Playing"
+          title={
+            <>
+              Now Playing{' '}
+              <StyledTag style={{ verticalAlign: 'middle', cursor: 'default' }}>
+                {playQueue.entry?.length || '...'}
+              </StyledTag>
+            </>
+          }
           subtitle={
             <>
               <ButtonToolbar>

--- a/src/components/settings/Config.tsx
+++ b/src/components/settings/Config.tsx
@@ -164,7 +164,7 @@ const Config = () => {
               </Whisper>
               <Whisper
                 trigger="hover"
-                placement="auto"
+                placement="bottomEnd"
                 enterable
                 preventOverflow
                 speaker={

--- a/src/components/shared/ColumnSort.tsx
+++ b/src/components/shared/ColumnSort.tsx
@@ -1,0 +1,55 @@
+import React, { useRef } from 'react';
+import { FlexboxGrid, RadioGroup } from 'rsuite';
+import { FilterHeader } from '../library/AdvancedFilters';
+import { StyledButton, StyledInputPickerContainer, StyledInputPicker, StyledRadio } from './styled';
+
+const ColumnSort = ({
+  sortColumns,
+  sortType,
+  sortColumn,
+  setSortType,
+  setSortColumn,
+  clearSortType,
+}: any) => {
+  const sortFilterPickerContainerRef = useRef<any>();
+
+  return (
+    <>
+      <FilterHeader>
+        <FlexboxGrid justify="space-between">
+          <FlexboxGrid.Item>Sort</FlexboxGrid.Item>
+          <FlexboxGrid.Item>
+            <StyledButton
+              size="xs"
+              appearance={sortColumn ? 'primary' : 'subtle'}
+              disabled={!sortColumn}
+              onClick={clearSortType}
+            >
+              Reset
+            </StyledButton>
+          </FlexboxGrid.Item>
+        </FlexboxGrid>
+      </FilterHeader>
+
+      <RadioGroup inline defaultValue={sortType} onChange={setSortType}>
+        <StyledRadio value="asc">ASC</StyledRadio>
+        <StyledRadio value="desc">DESC</StyledRadio>
+      </RadioGroup>
+      <StyledInputPickerContainer ref={sortFilterPickerContainerRef}>
+        <StyledInputPicker
+          container={() => sortFilterPickerContainerRef.current}
+          data={sortColumns}
+          value={sortColumn}
+          labelKey="label"
+          valueKey="dataKey"
+          virtualized
+          cleanable={false}
+          style={{ width: '250px' }}
+          onChange={setSortColumn}
+        />
+      </StyledInputPickerContainer>
+    </>
+  );
+};
+
+export default ColumnSort;

--- a/src/components/shared/ColumnSortPopover.tsx
+++ b/src/components/shared/ColumnSortPopover.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Whisper } from 'rsuite';
+import { StyledPopover } from './styled';
+import ColumnSort from './ColumnSort';
+
+const ColumnSortPopover = ({ children, ...rest }: any) => {
+  return (
+    <Whisper
+      trigger="click"
+      enterable
+      placement="bottomEnd"
+      preventOverflow
+      speaker={
+        <StyledPopover width="275px" placement="bottomEnd">
+          <ColumnSort {...rest} />
+        </StyledPopover>
+      }
+    >
+      {children}
+    </Whisper>
+  );
+};
+
+export default ColumnSortPopover;

--- a/src/components/shared/ToolbarButtons.tsx
+++ b/src/components/shared/ToolbarButtons.tsx
@@ -133,6 +133,15 @@ export const RefreshButton = ({ ...rest }) => {
   );
 };
 
+export const FilterButton = ({ ...rest }) => {
+  return (
+    <StyledButton tabIndex={0} {...rest}>
+      <Icon icon="filter" style={{ marginRight: '10px' }} />
+      Filter
+    </StyledButton>
+  );
+};
+
 export const AutoPlaylistButton = ({ noText, ...rest }: any) => {
   return (
     <CustomTooltip text="Auto playlist">

--- a/src/components/shared/styled.ts
+++ b/src/components/shared/styled.ts
@@ -16,6 +16,7 @@ import {
   TagPicker,
   Tag,
   CheckPicker,
+  Toggle,
 } from 'rsuite';
 import styled from 'styled-components';
 import TagLink from './TagLink';
@@ -174,6 +175,14 @@ export const StyledCheckbox = styled(Checkbox)`
         }
       }
     }
+  }
+`;
+
+export const StyledToggle = styled(Toggle)`
+  background-color: ${(props) => (props.checked ? props.theme.colors.primary : '')} !important;
+
+  .rs-btn-toggle-inner {
+    color: ${(props) => (props.checked ? props.theme.colors.button.primary.color : '')} !important;
   }
 `;
 

--- a/src/components/shared/styled.ts
+++ b/src/components/shared/styled.ts
@@ -15,6 +15,7 @@ import {
   Panel,
   TagPicker,
   Tag,
+  CheckPicker,
 } from 'rsuite';
 import styled from 'styled-components';
 import TagLink from './TagLink';
@@ -163,7 +164,9 @@ export const StyledCheckbox = styled(Checkbox)`
         span {
           &:before {
             background-color: ${(props) =>
-              props.defaultChecked ? `${props.theme.colors.primary} !important` : undefined};
+              props.checked || props.defaultChecked
+                ? `${props.theme.colors.primary} !important`
+                : undefined};
           }
           &:after {
             border: transparent !important;
@@ -438,12 +441,13 @@ export const ContextMenuPopover = styled(Popover)`
   z-index: 2000;
 `;
 
-export const StyledPopover = styled(Popover)`
+export const StyledPopover = styled(Popover)<{ width?: string }>`
   color: ${(props) => props.theme.colors.popover.color};
   background: ${(props) => props.theme.colors.popover.background};
   border: 1px #3c4043 solid;
   position: absolute;
   z-index: 1000;
+  width: ${(props) => props.width};
 `;
 
 export const SectionTitleWrapper = styled.div`
@@ -522,6 +526,8 @@ export const StyledTagPicker = styled(TagPicker)`
     border-radius: ${(props) => props.theme.other.tag.borderRadius};
   }
 `;
+
+export const StyledCheckPicker = styled(CheckPicker)``;
 
 export const StyledTag = styled(Tag)`
   color: ${(props) => props.theme.colors.tag.text} !important;

--- a/src/components/shared/styled.ts
+++ b/src/components/shared/styled.ts
@@ -255,7 +255,8 @@ export const StyledIconButton = styled(IconButton)`
 
 export const StyledNavItem = styled(Nav.Item)`
   a {
-    border-radius: ${(props) => props.theme.other.button.borderRadius} !important;
+    text-align: center;
+    border-radius: 0px !important;
     color: ${(props) =>
       props.active ? props.theme.colors.primary : props.theme.colors.nav.color} !important;
 

--- a/src/components/shared/styled.ts
+++ b/src/components/shared/styled.ts
@@ -359,6 +359,11 @@ export const StyledInputPickerContainer = styled.div`
       }
     }
   }
+
+  .rs-picker-search-bar-input {
+    background-color: ${(props) => props.theme.colors.input.background} !important;
+    border-color: #383838 !important;
+  }
 `;
 
 export const StyledInputPicker = styled(InputPicker)<{ width?: number }>`
@@ -536,7 +541,47 @@ export const StyledTagPicker = styled(TagPicker)`
   }
 `;
 
-export const StyledCheckPicker = styled(CheckPicker)``;
+export const StyledCheckPicker = styled(CheckPicker)`
+  border: 1px #3c3f43 solid !important;
+  border-radius: ${(props) => props.theme.other.input.borderRadius} !important;
+
+  &:hover,
+  &:active,
+  &:focus {
+    border-color: ${(props) => props.theme.colors.primary} !important;
+  }
+
+  a {
+    background: ${(props) => props.theme.colors.input.background} !important;
+
+    :hover {
+      background: ${(props) => props.theme.colors.input.backgroundHover} !important;
+    }
+
+    :active {
+      background: ${(props) => props.theme.colors.input.backgroundActive} !important;
+    }
+  }
+
+  .rs-picker-toggle {
+    border-radius: ${(props) => props.theme.other.input.borderRadius};
+  }
+
+  .hover {
+    border: ${(props) => `1px solid ${props.theme.colors.primary} !important`};
+  }
+
+  a {
+    span {
+      color: ${(props) => props.theme.colors.layout.page.color} !important;
+    }
+  }
+
+  .rs-picker-value-count {
+    background: ${(props) => props.theme.colors.primary};
+    color: ${(props) => props.theme.colors.button.primary.color} !important;
+  }
+`;
 
 export const StyledTag = styled(Tag)`
   color: ${(props) => props.theme.colors.tag.text} !important;

--- a/src/components/viewtypes/ListViewType.tsx
+++ b/src/components/viewtypes/ListViewType.tsx
@@ -119,7 +119,7 @@ const ListViewType = (
         const currentScrollY = Math.abs(tableRef?.current.scrollY);
         const currentScrollX = Math.abs(tableRef?.current.scrollX);
         if (dragDirection.match(/down|up/)) {
-          console.log(`currentScrollY + scrollDistance`, currentScrollY + scrollDistance);
+          // console.log(`currentScrollY + scrollDistance`, currentScrollY + scrollDistance);
           tableRef.current.scrollTop(
             dragDirection === 'down'
               ? currentScrollY + scrollDistance

--- a/src/hooks/useAdvancedFilter.ts
+++ b/src/hooks/useAdvancedFilter.ts
@@ -1,19 +1,13 @@
 import { useState, useEffect } from 'react';
 import _ from 'lodash';
-
-interface AdvancedFilters {
-  enabled: boolean;
-  properties: {
-    starred: boolean;
-    genre: {
-      list: any[];
-      type: 'or' | 'and';
-    };
-  };
-}
+import { AdvancedFilters } from '../redux/albumSlice';
 
 const useAdvancedFilter = (data: any[], filters: AdvancedFilters) => {
   const [filteredData, setFilteredData] = useState<any[]>([]);
+  const [byStarredData, setByStarredData] = useState<any[]>([]);
+  const [byGenreData, setByGenreData] = useState<any[]>([]);
+  const [byArtistData, setByArtistData] = useState<any[]>([]);
+
   const [filterProps, setFilterProps] = useState(filters);
 
   useEffect(() => {
@@ -48,13 +42,38 @@ const useAdvancedFilter = (data: any[], filters: AdvancedFilters) => {
             })
           : filteredByStarred;
 
-      setFilteredData(_.compact(_.uniqBy(filteredByGenres, 'uniqueId')));
+      const artistRegex = new RegExp(filterProps.properties?.artist?.list.join('|'), 'i');
+
+      const filteredByArtists =
+        filterProps.properties.artist.list.length > 0
+          ? (filteredByGenres || []).filter((entry) => {
+              const entryArtistIds = _.map(entry.artist, 'id');
+
+              if (filterProps.properties.artist.type === 'or') {
+                return entryArtistIds.some((artistId) => artistId.match(artistRegex));
+              }
+
+              const matches = [];
+              for (let i = 0; i < filterProps.properties.artist.list.length; i += 1) {
+                if (entryArtistIds.includes(filterProps.properties.artist.list[i])) {
+                  matches.push(entry);
+                }
+              }
+
+              return matches.length === filterProps.properties.artist.list.length;
+            })
+          : filteredByGenres;
+
+      setByStarredData(_.compact(_.uniqBy(filteredByStarred, 'uniqueId')));
+      setByGenreData(_.compact(_.uniqBy(filteredByGenres, 'uniqueId')));
+      setByArtistData(_.compact(_.uniqBy(filteredByArtists, 'uniqueId')));
+      setFilteredData(_.compact(_.uniqBy(filteredByArtists, 'uniqueId')));
     } else {
       setFilteredData(data);
     }
   }, [data, filterProps, filters]);
 
-  return filteredData;
+  return { filteredData, byStarredData, byGenreData, byArtistData };
 };
 
 export default useAdvancedFilter;

--- a/src/hooks/useAdvancedFilter.ts
+++ b/src/hooks/useAdvancedFilter.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react';
+import _ from 'lodash';
+
+interface AdvancedFilters {
+  enabled: boolean;
+  properties: {
+    starred: boolean;
+    genre: {
+      list: any[];
+      type: 'or' | 'and';
+    };
+  };
+}
+
+const useAdvancedFilter = (data: any[], filters: AdvancedFilters) => {
+  const [filteredData, setFilteredData] = useState<any[]>([]);
+  const [filterProps, setFilterProps] = useState(filters);
+
+  useEffect(() => {
+    setFilterProps(filters);
+    if (filterProps.enabled) {
+      // Favorite/Star filter
+      const filteredByStarred = filterProps.properties.starred
+        ? (data || []).filter((entry) => {
+            return entry.starred !== undefined;
+          })
+        : data;
+
+      // Genre filter
+      const genreRegex = new RegExp(filterProps.properties?.genre?.list.join('|'), 'i');
+      const filteredByGenres =
+        filterProps.properties.genre.list.length > 0
+          ? (filteredByStarred || []).filter((entry) => {
+              const entryGenres = _.map(entry.genre, 'title');
+
+              if (filterProps.properties.genre.type === 'or') {
+                return entryGenres.some((genre) => genre.match(genreRegex));
+              }
+
+              const matches = [];
+              for (let i = 0; i < filterProps.properties.genre.list.length; i += 1) {
+                if (entryGenres.includes(filterProps.properties.genre.list[i])) {
+                  matches.push(entry);
+                }
+              }
+
+              return matches.length === filterProps.properties.genre.list.length;
+            })
+          : filteredByStarred;
+
+      setFilteredData(_.compact(_.uniqBy(filteredByGenres, 'uniqueId')));
+    } else {
+      setFilteredData(data);
+    }
+  }, [data, filterProps, filters]);
+
+  return filteredData;
+};
+
+export default useAdvancedFilter;

--- a/src/hooks/useAdvancedFilter.ts
+++ b/src/hooks/useAdvancedFilter.ts
@@ -7,6 +7,7 @@ const useAdvancedFilter = (data: any[], filters: AdvancedFilters) => {
   const [byStarredData, setByStarredData] = useState<any[]>([]);
   const [byGenreData, setByGenreData] = useState<any[]>([]);
   const [byArtistData, setByArtistData] = useState<any[]>([]);
+  const [byArtistBaseData, setByArtistBaseData] = useState<any[]>([]);
 
   const [filterProps, setFilterProps] = useState(filters);
 
@@ -64,16 +65,38 @@ const useAdvancedFilter = (data: any[], filters: AdvancedFilters) => {
             })
           : filteredByGenres;
 
+      // Instead of filtering from the previous (genre), start from the starred filter
+      const filteredByArtistsBase =
+        filterProps.properties.artist.list.length > 0
+          ? (filteredByStarred || []).filter((entry) => {
+              const entryArtistIds = _.map(entry.artist, 'id');
+
+              if (filterProps.properties.artist.type === 'or') {
+                return entryArtistIds.some((artistId) => artistId.match(artistRegex));
+              }
+
+              const matches = [];
+              for (let i = 0; i < filterProps.properties.artist.list.length; i += 1) {
+                if (entryArtistIds.includes(filterProps.properties.artist.list[i])) {
+                  matches.push(entry);
+                }
+              }
+
+              return matches.length === filterProps.properties.artist.list.length;
+            })
+          : filteredByStarred;
+
       setByStarredData(_.compact(_.uniqBy(filteredByStarred, 'uniqueId')));
       setByGenreData(_.compact(_.uniqBy(filteredByGenres, 'uniqueId')));
       setByArtistData(_.compact(_.uniqBy(filteredByArtists, 'uniqueId')));
+      setByArtistBaseData(_.compact(_.uniqBy(filteredByArtistsBase, 'uniqueId')));
       setFilteredData(_.compact(_.uniqBy(filteredByArtists, 'uniqueId')));
     } else {
       setFilteredData(data);
     }
   }, [data, filterProps, filters]);
 
-  return { filteredData, byStarredData, byGenreData, byArtistData };
+  return { filteredData, byStarredData, byGenreData, byArtistData, byArtistBaseData };
 };
 
 export default useAdvancedFilter;

--- a/src/hooks/useAdvancedFilter.ts
+++ b/src/hooks/useAdvancedFilter.ts
@@ -8,6 +8,7 @@ const useAdvancedFilter = (data: any[], filters: AdvancedFilters) => {
   const [byGenreData, setByGenreData] = useState<any[]>([]);
   const [byArtistData, setByArtistData] = useState<any[]>([]);
   const [byArtistBaseData, setByArtistBaseData] = useState<any[]>([]);
+  const [byYearData, setByYearData] = useState<any[]>([]);
 
   const [filterProps, setFilterProps] = useState(filters);
 
@@ -86,17 +87,41 @@ const useAdvancedFilter = (data: any[], filters: AdvancedFilters) => {
             })
           : filteredByStarred;
 
+      const filteredByYear = !(
+        filterProps.properties.year.from === 0 && filterProps.properties.year.to === 0
+      )
+        ? (filteredByArtists || []).filter((entry) => {
+            if (filterProps.properties.year.from !== 0 && filterProps.properties.year.to === 0) {
+              return entry.year && entry.year >= filterProps.properties.year.from;
+            }
+
+            if (filterProps.properties.year.from === 0 && filterProps.properties.year.to !== 0) {
+              return entry.year && entry.year <= filterProps.properties.year.to;
+            }
+
+            if (filterProps.properties.year.from !== 0 && filterProps.properties.year.to !== 0) {
+              return (
+                entry.year &&
+                entry.year >= filterProps.properties.year.from &&
+                entry.year <= filterProps.properties.year.to
+              );
+            }
+            return undefined;
+          })
+        : filteredByArtists;
+
       setByStarredData(_.compact(_.uniqBy(filteredByStarred, 'uniqueId')));
       setByGenreData(_.compact(_.uniqBy(filteredByGenres, 'uniqueId')));
       setByArtistData(_.compact(_.uniqBy(filteredByArtists, 'uniqueId')));
       setByArtistBaseData(_.compact(_.uniqBy(filteredByArtistsBase, 'uniqueId')));
-      setFilteredData(_.compact(_.uniqBy(filteredByArtists, 'uniqueId')));
+      setByYearData(_.compact(_.uniqBy(filteredByYear, 'uniqueId')));
+      setFilteredData(_.compact(_.uniqBy(filteredByYear, 'uniqueId')));
     } else {
       setFilteredData(data);
     }
   }, [data, filterProps, filters]);
 
-  return { filteredData, byStarredData, byGenreData, byArtistData, byArtistBaseData };
+  return { filteredData, byStarredData, byGenreData, byArtistData, byArtistBaseData, byYearData };
 };
 
 export default useAdvancedFilter;

--- a/src/hooks/useColumnSort.ts
+++ b/src/hooks/useColumnSort.ts
@@ -1,0 +1,109 @@
+/* eslint-disable array-callback-return */
+/* eslint-disable consistent-return */
+import { useState, useEffect } from 'react';
+import _ from 'lodash';
+import { Item } from '../types';
+
+const ALBUM_COLUMNS = [
+  { label: 'Artist', dataKey: 'albumArtist' },
+  { label: 'Created', dataKey: 'created' },
+  { label: 'Duration', dataKey: 'duration' },
+  { label: 'Favorite', dataKey: 'starred' },
+  { label: 'Genre', dataKey: 'albumGenre' },
+  { label: 'Rating', dataKey: 'userRating' },
+  { label: 'Song Count', dataKey: 'songCount' },
+  { label: 'Title', dataKey: 'title' },
+  { label: 'Year', dataKey: 'year' },
+];
+
+const ARTIST_COLUMNS = [
+  { label: 'Album Count', dataKey: 'albumCount' },
+  { label: 'Duration', dataKey: 'duration' },
+  { label: 'Favorite', dataKey: 'starred' },
+  { label: 'Rating', dataKey: 'userRating' },
+  { label: 'Title', dataKey: 'title' },
+];
+
+const MUSIC_COLUMNS = [
+  { label: 'Artist', dataKey: 'albumArtist' },
+  { label: 'Bitrate', dataKey: 'bitRate' },
+  { label: 'Created', dataKey: 'created' },
+  { label: 'Duration', dataKey: 'duration' },
+  { label: 'Favorite', dataKey: 'starred' },
+  { label: 'Genre', dataKey: 'albumGenre' },
+  { label: 'Play Count', dataKey: 'playCount' },
+  { label: 'Rating', dataKey: 'userRating' },
+  { label: 'Size', dataKey: 'size' },
+  { label: 'Title', dataKey: 'title' },
+  { label: 'Year', dataKey: 'year' },
+];
+
+const PLAYLIST_COLUMNS = [
+  { label: 'Comment', dataKey: 'comment' },
+  { label: 'Created', dataKey: 'created' },
+  { label: 'Duration', dataKey: 'duration' },
+  { label: 'Modified', dataKey: 'modified' },
+  { label: 'Owner', dataKey: 'owner' },
+  { label: 'Public', dataKey: 'public' },
+  { label: 'Song Count', dataKey: 'songCount' },
+  { label: 'Title', dataKey: 'title' },
+];
+
+const GENRE_COLUMNS = [
+  { label: 'Album Count', dataKey: 'albumCount' },
+  { label: 'Song Count', dataKey: 'songCount' },
+  { label: 'Title', dataKey: 'title' },
+];
+
+const useColumnSort = (data: any[], type: Item, sort: { column: string; type: 'asc' | 'desc' }) => {
+  const [sortProps, setSortProps] = useState<any>(sort);
+  const [sortedData, setSortedData] = useState<any[]>([]);
+  const [sortColumns, setSortColumns] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (type === Item.Album) {
+      return setSortColumns(ALBUM_COLUMNS);
+    }
+
+    if (type === Item.Artist) {
+      return setSortColumns(ARTIST_COLUMNS);
+    }
+
+    if (type === Item.Music) {
+      return setSortColumns(MUSIC_COLUMNS);
+    }
+
+    if (type === Item.Genre) {
+      return setSortColumns(GENRE_COLUMNS);
+    }
+
+    if (type === Item.Playlist) {
+      return setSortColumns(PLAYLIST_COLUMNS);
+    }
+  }, [type]);
+
+  useEffect(() => {
+    setSortProps(sort);
+
+    const sortedByColumn = sortProps.column
+      ? _.orderBy(
+          data,
+          [
+            (entry: any) => {
+              return typeof entry[sortProps.column!] === 'string'
+                ? entry[sortProps.column!].toLowerCase() || ''
+                : +entry[sortProps.column!] || '';
+            },
+          ],
+          sortProps.type
+        )
+      : data;
+
+    setSortedData(_.compact(_.uniqBy(sortedByColumn, 'uniqueId')));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, sort.column, sort.type, sortProps.column, sortProps.type]);
+
+  return { sortedData, sortColumns };
+};
+
+export default useColumnSort;

--- a/src/hooks/useColumnSort.ts
+++ b/src/hooks/useColumnSort.ts
@@ -99,7 +99,7 @@ const useColumnSort = (data: any[], type: Item, sort: { column: string; type: 'a
         )
       : data;
 
-    setSortedData(_.compact(_.uniqBy(sortedByColumn, 'uniqueId')));
+    setSortedData(sortedByColumn);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, sort.column, sort.type, sortProps.column, sortProps.type]);
 

--- a/src/redux/albumSlice.ts
+++ b/src/redux/albumSlice.ts
@@ -4,11 +4,33 @@ export interface AlbumPage {
   active: {
     filter: string;
   };
+  advancedFilters: AdvancedFilters;
+}
+
+export interface AdvancedFilters {
+  enabled: boolean;
+  properties: {
+    starred: boolean;
+    genre: {
+      list: any[];
+      type: 'and' | 'or';
+    };
+  };
 }
 
 const initialState: AlbumPage = {
   active: {
     filter: 'random',
+  },
+  advancedFilters: {
+    enabled: false,
+    properties: {
+      starred: false,
+      genre: {
+        list: [],
+        type: 'and',
+      },
+    },
   },
 };
 
@@ -19,8 +41,12 @@ const albumSlice = createSlice({
     setActive: (state, action: PayloadAction<any>) => {
       state.active = action.payload;
     },
+
+    setAdvancedFilters: (state, action: PayloadAction<any>) => {
+      state.advancedFilters = action.payload;
+    },
   },
 });
 
-export const { setActive } = albumSlice.actions;
+export const { setActive, setAdvancedFilters } = albumSlice.actions;
 export default albumSlice.reducer;

--- a/src/redux/albumSlice.ts
+++ b/src/redux/albumSlice.ts
@@ -15,6 +15,10 @@ export interface AdvancedFilters {
       list: any[];
       type: 'and' | 'or';
     };
+    artist: {
+      list: any[];
+      type: 'and' | 'or';
+    };
   };
 }
 
@@ -27,6 +31,10 @@ const initialState: AlbumPage = {
     properties: {
       starred: false,
       genre: {
+        list: [],
+        type: 'and',
+      },
+      artist: {
         list: [],
         type: 'and',
       },
@@ -56,6 +64,10 @@ const albumSlice = createSlice({
 
       if (action.payload.filter === 'genre') {
         state.advancedFilters.properties.genre = action.payload.value;
+      }
+
+      if (action.payload.filter === 'artist') {
+        state.advancedFilters.properties.artist = action.payload.value;
       }
     },
   },

--- a/src/redux/albumSlice.ts
+++ b/src/redux/albumSlice.ts
@@ -19,6 +19,10 @@ export interface AdvancedFilters {
       list: any[];
       type: 'and' | 'or';
     };
+    year: {
+      from: number;
+      to: number;
+    };
   };
 }
 
@@ -38,6 +42,10 @@ const initialState: AlbumPage = {
         list: [],
         type: 'and',
       },
+      year: {
+        from: 0,
+        to: 0,
+      },
     },
   },
 };
@@ -52,7 +60,10 @@ const albumSlice = createSlice({
 
     setAdvancedFilters: (
       state,
-      action: PayloadAction<{ filter: 'enabled' | 'starred' | 'genre' | 'artist'; value: any }>
+      action: PayloadAction<{
+        filter: 'enabled' | 'starred' | 'genre' | 'artist' | 'year';
+        value: any;
+      }>
     ) => {
       if (action.payload.filter === 'enabled') {
         state.advancedFilters.enabled = action.payload.value;
@@ -68,6 +79,10 @@ const albumSlice = createSlice({
 
       if (action.payload.filter === 'artist') {
         state.advancedFilters.properties.artist = action.payload.value;
+      }
+
+      if (action.payload.filter === 'year') {
+        state.advancedFilters.properties.year = action.payload.value;
       }
     },
   },

--- a/src/redux/albumSlice.ts
+++ b/src/redux/albumSlice.ts
@@ -42,8 +42,21 @@ const albumSlice = createSlice({
       state.active = action.payload;
     },
 
-    setAdvancedFilters: (state, action: PayloadAction<any>) => {
-      state.advancedFilters = action.payload;
+    setAdvancedFilters: (
+      state,
+      action: PayloadAction<{ filter: 'enabled' | 'starred' | 'genre' | 'artist'; value: any }>
+    ) => {
+      if (action.payload.filter === 'enabled') {
+        state.advancedFilters.enabled = action.payload.value;
+      }
+
+      if (action.payload.filter === 'starred') {
+        state.advancedFilters.properties.starred = action.payload.value;
+      }
+
+      if (action.payload.filter === 'genre') {
+        state.advancedFilters.properties.genre = action.payload.value;
+      }
     },
   },
 });

--- a/src/redux/albumSlice.ts
+++ b/src/redux/albumSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Sort } from '../types';
 
 export interface AlbumPage {
   active: {
@@ -9,6 +10,7 @@ export interface AlbumPage {
 
 export interface AdvancedFilters {
   enabled: boolean;
+  nav: 'filters' | 'sort';
   properties: {
     starred: boolean;
     genre: {
@@ -23,6 +25,7 @@ export interface AdvancedFilters {
       from: number;
       to: number;
     };
+    sort: Sort;
   };
 }
 
@@ -32,6 +35,7 @@ const initialState: AlbumPage = {
   },
   advancedFilters: {
     enabled: false,
+    nav: 'filters',
     properties: {
       starred: false,
       genre: {
@@ -45,6 +49,10 @@ const initialState: AlbumPage = {
       year: {
         from: 0,
         to: 0,
+      },
+      sort: {
+        column: undefined,
+        type: 'asc',
       },
     },
   },
@@ -61,7 +69,7 @@ const albumSlice = createSlice({
     setAdvancedFilters: (
       state,
       action: PayloadAction<{
-        filter: 'enabled' | 'starred' | 'genre' | 'artist' | 'year';
+        filter: 'enabled' | 'starred' | 'genre' | 'artist' | 'year' | 'sort' | 'nav';
         value: any;
       }>
     ) => {
@@ -83,6 +91,14 @@ const albumSlice = createSlice({
 
       if (action.payload.filter === 'year') {
         state.advancedFilters.properties.year = action.payload.value;
+      }
+
+      if (action.payload.filter === 'sort') {
+        state.advancedFilters.properties.sort = action.payload.value;
+      }
+
+      if (action.payload.filter === 'nav') {
+        state.advancedFilters.nav = action.payload.value;
       }
     },
   },

--- a/src/redux/artistSlice.ts
+++ b/src/redux/artistSlice.ts
@@ -1,0 +1,53 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Sort } from '../types';
+
+export interface ArtistPage {
+  active: {
+    list: {
+      sort: Sort;
+    };
+    page: {
+      sort: Sort;
+    };
+  };
+}
+
+const initialState: ArtistPage = {
+  active: {
+    list: {
+      sort: {
+        column: undefined,
+        type: 'asc',
+      },
+    },
+    page: {
+      sort: {
+        column: undefined,
+        type: 'asc',
+      },
+    },
+  },
+};
+
+const artistSlice = createSlice({
+  name: 'artist',
+  initialState,
+  reducers: {
+    setActive: (state, action: PayloadAction<any>) => {
+      state.active = action.payload;
+    },
+
+    setSort: (state, action: PayloadAction<{ type: 'list' | 'page'; value: Sort }>) => {
+      if (action.payload.type === 'list') {
+        state.active.list.sort = action.payload.value;
+      }
+
+      if (action.payload.type === 'page') {
+        state.active.page.sort = action.payload.value;
+      }
+    },
+  },
+});
+
+export const { setActive, setSort } = artistSlice.actions;
+export default artistSlice.reducer;

--- a/src/redux/favoriteSlice.ts
+++ b/src/redux/favoriteSlice.ts
@@ -1,14 +1,33 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Sort } from '../types';
 
 export interface FavoritePage {
   active: {
     tab: string;
+    album: {
+      sort: Sort;
+    };
+    artist: {
+      sort: Sort;
+    };
   };
 }
 
 const initialState: FavoritePage = {
   active: {
     tab: 'tracks',
+    album: {
+      sort: {
+        column: undefined,
+        type: 'asc',
+      },
+    },
+    artist: {
+      sort: {
+        column: undefined,
+        type: 'asc',
+      },
+    },
   },
 };
 
@@ -19,8 +38,18 @@ const favoriteSlice = createSlice({
     setActive: (state, action: PayloadAction<{ tab: string }>) => {
       state.active.tab = action.payload.tab;
     },
+
+    setSort: (state, action: PayloadAction<{ type: 'album' | 'artist'; value: Sort }>) => {
+      if (action.payload.type === 'album') {
+        state.active.album.sort = action.payload.value;
+      }
+
+      if (action.payload.type === 'artist') {
+        state.active.artist.sort = action.payload.value;
+      }
+    },
   },
 });
 
-export const { setActive } = favoriteSlice.actions;
+export const { setActive, setSort } = favoriteSlice.actions;
 export default favoriteSlice.reducer;

--- a/src/redux/playlistSlice.ts
+++ b/src/redux/playlistSlice.ts
@@ -7,14 +7,37 @@ import {
   moveSelectedToTop,
   moveSelectedUp,
 } from '../shared/utils';
+import { Sort } from '../types';
 import { Entry } from './playQueueSlice';
 
 export interface Playlist {
+  active: {
+    list: {
+      sort: Sort;
+    };
+    page: {
+      sort: Sort;
+    };
+  };
   entry: Entry[];
   sortedEntry: Entry[];
 }
 
 const initialState: Playlist = {
+  active: {
+    list: {
+      sort: {
+        column: undefined,
+        type: 'asc',
+      },
+    },
+    page: {
+      sort: {
+        column: undefined,
+        type: 'asc',
+      },
+    },
+  },
   entry: [],
   sortedEntry: [],
 };
@@ -23,6 +46,16 @@ const playlistSlice = createSlice({
   name: 'playlist',
   initialState,
   reducers: {
+    setSort: (state, action: PayloadAction<{ type: 'list' | 'page'; value: Sort }>) => {
+      if (action.payload.type === 'list') {
+        state.active.list.sort = action.payload.value;
+      }
+
+      if (action.payload.type === 'page') {
+        state.active.page.sort = action.payload.value;
+      }
+    },
+
     setPlaylistData: (state, action: PayloadAction<Entry[]>) => {
       state.entry = action.payload;
     },
@@ -129,5 +162,6 @@ export const {
   moveToTop,
   setPlaylistStar,
   setPlaylistRate,
+  setSort,
 } = playlistSlice.actions;
 export default playlistSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -9,6 +9,7 @@ import folderReducer from './folderSlice';
 import configReducer from './configSlice';
 import favoriteReducer from './favoriteSlice';
 import albumReducer from './albumSlice';
+import artistReducer from './artistSlice';
 
 export const store = configureStore<PlayQueue | any>({
   reducer: {
@@ -21,6 +22,7 @@ export const store = configureStore<PlayQueue | any>({
     config: configReducer,
     favorite: favoriteReducer,
     album: albumReducer,
+    artist: artistReducer,
   },
   middleware: [forwardToMain],
 });

--- a/src/styles/App.global.css
+++ b/src/styles/App.global.css
@@ -43,6 +43,10 @@ body {
   padding: 0px;
 }
 
+.rs-popover.in {
+  opacity: 0.97 !important;
+}
+
 .react-horizontal-scrolling-menu--scroll-container::-webkit-scrollbar {
   display: none;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,3 +171,8 @@ export interface ScanStatus {
   scanning: boolean;
   count: number | 'N/a';
 }
+
+export interface Sort {
+  column?: string;
+  type: 'asc' | 'desc';
+}


### PR DESCRIPTION
Closes #66 

**Preview (subject to change)**
![image](https://user-images.githubusercontent.com/42182408/145785227-7e224f36-f6f1-4d96-994a-2ef4d5d5f6b2.png)
![image](https://user-images.githubusercontent.com/42182408/145785250-023c196d-5d99-4186-842e-a0bb34f95f3e.png)


- [x] Enable/Disable advanced filter
- [x] Genre AND/OR filter
- [x] Artist AND/OR filter
- [x] Year TO/FROM filter
- [x] Column (Title, Artist, etc.) ASC/DESC filter

**Note:**
- All filtering is done on the client-side to mitigate limitations from both Subsonic/Jellyfin APIs
 - `AND` filters have limited functionality for Subsonic-API due to not supporting multi-genre and multi-artist fields. 