### PR TITLE
Support jellyfin recently played/most played on dashboard

### DIFF
--- a/src/api/controller.ts
+++ b/src/api/controller.ts
@@ -61,6 +61,7 @@ import {
   updatePlaylistSongs as jfUpdatePlaylistSongs,
   updatePlaylistSongsLg as jfUpdatePlaylingSongsLg,
   updatePlaylist as jfUpdatePlaylist,
+  getSongs as jfGetSongs,
 } from './jellyfinApi';
 import { APIEndpoints, ServerType } from '../types';
 
@@ -91,6 +92,7 @@ const endpoints = [
   { id: 'getMusicDirectory', endpoint: { subsonic: getMusicDirectory, jellyfin: jfGetMusicDirectory } },
   { id: 'getMusicDirectorySongs', endpoint: { subsonic: getMusicDirectorySongs, jellyfin: jfGetMusicDirectorySongs } },
   { id: 'getDownloadUrl', endpoint: { subsonic: getDownloadUrl, jellyfin: jfGetDownloadUrl } },
+  { id: 'getSongs', endpoint: { subsonic: undefined, jellyfin: jfGetSongs } },
 
   // Playlist handling logic is split up by server type due to differences in how each server handles them.
   // You will need to add custom logic in the playlist/context menu component handlers.

--- a/src/api/jellyfinApi.ts
+++ b/src/api/jellyfinApi.ts
@@ -392,7 +392,7 @@ export const getAlbums = async (options: {
       fields: 'Genres, DateCreated, ChildCount, ParentId',
       includeItemTypes: 'MusicAlbum',
       limit: options.size,
-      offset: options.offset,
+      startIndex: options.offset,
       parentId: options.musicFolderId,
       recursive: true,
       sortBy: sortType!.replacement,
@@ -401,6 +401,65 @@ export const getAlbums = async (options: {
   });
 
   return (data.Items || []).map((entry: any) => normalizeAlbum(entry));
+};
+
+export const getSongs = async (options: {
+  type: any;
+  size: number;
+  offset: number;
+  recursive: boolean;
+  order: 'asc' | 'desc';
+  musicFolderId?: string;
+}) => {
+  const sortTypes = [
+    { original: 'alphabeticalByName', replacement: 'SortName' },
+    { original: 'alphabeticalByArtist', replacement: 'AlbumArtist' },
+    { original: 'alphabeticalByTrackArtist', replacement: 'Artist' },
+    { original: 'frequent', replacement: 'PlayCount' },
+    { original: 'random', replacement: 'Random' },
+    { original: 'newest', replacement: 'DateCreated' },
+    { original: 'recent', replacement: 'DatePlayed' },
+    { original: 'playCount', replacement: 'PlayCount' },
+    { original: 'year', replacement: 'PremiereDate' },
+    { original: 'duration', replacement: 'Runtime' },
+  ];
+
+  const sortType = sortTypes.find((type) => type.original === options.type);
+
+  if (options.recursive) {
+    const { data } = await jellyfinApi.get(`/users/${auth.username}/items`, {
+      params: {
+        fields: 'Genres, DateCreated, MediaSources, ParentId',
+        genres: !sortType ? options.type : undefined,
+        includeItemTypes: 'Audio',
+        parentId: options.musicFolderId,
+        recursive: true,
+        sortBy: sortType ? sortType!.replacement : 'SortName',
+        sortOrder: options.order === 'asc' ? 'Ascending' : 'Descending',
+        imageTypeLimit: 1,
+        enableImageTypes: 'Primary',
+      },
+    });
+
+    return (data.Items || []).map((entry: any) => normalizeSong(entry));
+  }
+
+  const { data } = await jellyfinApi.get(`/users/${auth.username}/items`, {
+    params: {
+      fields: 'Genres, DateCreated, MediaSources, ParentId',
+      includeItemTypes: 'Audio',
+      limit: options.size,
+      startIndex: options.offset,
+      parentId: options.musicFolderId,
+      recursive: true,
+      sortBy: sortType!.replacement,
+      sortOrder: options.order === 'asc' ? 'Ascending' : 'Descending',
+      imageTypeLimit: 1,
+      enableImageTypes: 'Primary',
+    },
+  });
+
+  return (data.Items || []).map((entry: any) => normalizeSong(entry));
 };
 
 export const getArtist = async (options: { id: string; musicFolderId?: string }) => {

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -82,7 +82,7 @@ const Card = ({
       notifyToast('info', getPlayedSongsNotification({ ...songs.count, type: 'play' }));
     }
 
-    if (playClick.type === 'album') {
+    if (playClick.type === 'album' || playClick.type === 'music') {
       const res = await apiController({
         serverType: config.serverType,
         endpoint: 'getAlbum',
@@ -143,7 +143,7 @@ const Card = ({
       notifyToast('info', getPlayedSongsNotification({ ...songs.count, type: 'add' }));
     }
 
-    if (playClick.type === 'album') {
+    if (playClick.type === 'album' || playClick.type === 'music') {
       const res = await apiController({
         serverType: config.serverType,
         endpoint: 'getAlbum',

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -10,6 +10,7 @@ import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { setStar } from '../../redux/playQueueSlice';
 import { setActive } from '../../redux/albumSlice';
 import { apiController } from '../../api/controller';
+import { Server } from '../../types';
 
 const Dashboard = () => {
   const history = useHistory();
@@ -31,9 +32,13 @@ const Dashboard = () => {
     () =>
       apiController({
         serverType: config.serverType,
-        endpoint: 'getAlbums',
-        args: { type: 'recent', size: 20, offset: 0, musicFolderId: musicFolder },
-      })
+        endpoint: config.serverType === Server.Jellyfin ? 'getSongs' : 'getAlbums',
+        args: { type: 'recent', size: 20, offset: 0, order: 'desc', musicFolderId: musicFolder },
+      }),
+    {
+      refetchOnWindowFocus: true,
+      refetchInterval: 30000,
+    }
   );
 
   const { isLoading: isLoadingNewest, data: newestAlbums }: any = useQuery(
@@ -61,9 +66,12 @@ const Dashboard = () => {
     () =>
       apiController({
         serverType: config.serverType,
-        endpoint: 'getAlbums',
-        args: { type: 'frequent', size: 20, offset: 0, musicFolderId: musicFolder },
-      })
+        endpoint: config.serverType === Server.Jellyfin ? 'getSongs' : 'getAlbums',
+        args: { type: 'frequent', size: 20, offset: 0, order: 'desc', musicFolderId: musicFolder },
+      }),
+    {
+      refetchOnWindowFocus: true,
+    }
   );
 
   const handleFavorite = async (rowData: any) => {
@@ -180,7 +188,7 @@ const Dashboard = () => {
                 history.push(`/library/album?sortType=recent`);
               }, 50);
             }}
-            type="album"
+            type="music"
             handleFavorite={handleFavorite}
           />
 
@@ -252,7 +260,7 @@ const Dashboard = () => {
                 history.push(`/library/album?sortType=frequent`);
               }, 50);
             }}
-            type="album"
+            type="music"
             handleFavorite={handleFavorite}
           />
         </>

--- a/src/components/library/AlbumList.tsx
+++ b/src/components/library/AlbumList.tsx
@@ -257,6 +257,9 @@ const AlbumList = () => {
                   value={album.active.filter}
                   groupBy="role"
                   data={sortTypes}
+                  disabledItemValues={
+                    config.serverType === Server.Jellyfin ? ['frequent', 'recent'] : []
+                  }
                   cleanable={false}
                   placeholder="Sort Type"
                   onChange={async (value: string) => {
@@ -317,6 +320,9 @@ const AlbumList = () => {
                         sortColumns={sortColumns}
                         sortColumn={album.advancedFilters.properties.sort.column}
                         sortType={album.advancedFilters.properties.sort.type}
+                        disabledItemValues={
+                          config.serverType === Server.Jellyfin ? ['playCount', 'userRating'] : []
+                        }
                         clearSortType={() =>
                           dispatch(
                             setAdvancedFilters({

--- a/src/components/library/ArtistList.tsx
+++ b/src/components/library/ArtistList.tsx
@@ -161,6 +161,9 @@ const ArtistList = () => {
               sortColumns={sortColumns}
               sortColumn={artist.active.list.sort.column}
               sortType={artist.active.list.sort.type}
+              disabledItemValues={
+                config.serverType === Server.Jellyfin ? ['albumCount', 'userRating'] : ['duration']
+              }
               clearSortType={() =>
                 dispatch(
                   setSort({

--- a/src/components/playlist/PlaylistList.tsx
+++ b/src/components/playlist/PlaylistList.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../redux/multiSelectSlice';
 import { apiController } from '../../api/controller';
 import useColumnSort from '../../hooks/useColumnSort';
-import { Item } from '../../types';
+import { Item, Server } from '../../types';
 import { setSort } from '../../redux/playlistSlice';
 import ColumnSortPopover from '../shared/ColumnSortPopover';
 
@@ -124,6 +124,9 @@ const PlaylistList = () => {
                 sortColumns={sortColumns}
                 sortColumn={playlist.active.list.sort.column}
                 sortType={playlist.active.list.sort.type}
+                disabledItemValues={
+                  config.serverType === Server.Jellyfin ? ['changed', 'owner', 'public'] : []
+                }
                 clearSortType={() =>
                   dispatch(
                     setSort({

--- a/src/components/scrollingmenu/ScrollingMenu.tsx
+++ b/src/components/scrollingmenu/ScrollingMenu.tsx
@@ -88,13 +88,17 @@ const ScrollingMenu = ({
                   : item[cardSubtitle.property]
               }
               coverArt={item.image}
-              url={cardTitle.urlProperty ? `${cardTitle.prefix}/${item.id}` : undefined}
+              url={
+                cardTitle.urlProperty
+                  ? `${cardTitle.prefix}/${type === 'music' ? item.albumId : item.id}`
+                  : undefined
+              }
               subUrl={
                 cardSubtitle.urlProperty
                   ? `${cardSubtitle.prefix}/${item[cardSubtitle.urlProperty]}`
                   : undefined
               }
-              playClick={{ type, id: item.id }}
+              playClick={{ type, id: type === 'music' ? item.albumId : item.id }}
               details={{ cacheType: type, ...item }}
               hasHoverButtons
               size={config.lookAndFeel.gridView.cardSize}

--- a/src/components/settings/ConfigPanels/ListViewConfig.tsx
+++ b/src/components/settings/ConfigPanels/ListViewConfig.tsx
@@ -51,7 +51,13 @@ const columnSelectorColumns = [
   },
 ];
 
-const ListViewConfig = ({ defaultColumns, columnPicker, columnList, settingsConfig }: any) => {
+const ListViewConfig = ({
+  defaultColumns,
+  columnPicker,
+  columnList,
+  settingsConfig,
+  disabledItemValues,
+}: any) => {
   const dispatch = useAppDispatch();
   const playQueue = useAppSelector((state) => state.playQueue);
   const multiSelect = useAppSelector((state) => state.multiSelect);
@@ -112,6 +118,7 @@ const ListViewConfig = ({ defaultColumns, columnPicker, columnList, settingsConf
               data={columnPicker}
               defaultValue={defaultColumns}
               value={selectedColumns}
+              disabledItemValues={disabledItemValues}
               style={{ width: '100%' }}
               onChange={(e: any) => {
                 const columns: any[] = [];

--- a/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
+++ b/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
@@ -37,6 +37,7 @@ import {
   setGridCardSize,
   setGridGapSize,
 } from '../../../redux/configSlice';
+import { Server } from '../../../types';
 
 export const ListViewConfigPanel = ({ bordered }: any) => {
   const dispatch = useAppDispatch();
@@ -84,6 +85,7 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
             rowHeight: 'musicListRowHeight',
             fontSize: 'musicListFontSize',
           }}
+          disabledItemValues={config.serverType === Server.Jellyfin ? ['Path'] : []}
         />
       )}
 
@@ -98,6 +100,7 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
             rowHeight: 'albumListRowHeight',
             fontSize: 'albumListFontSize',
           }}
+          disabledItemValues={config.serverType === Server.Jellyfin ? ['Rating'] : []}
         />
       )}
 
@@ -112,6 +115,11 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
             rowHeight: 'playlistListRowHeight',
             fontSize: 'playlistListFontSize',
           }}
+          disabledItemValues={
+            config.serverType === Server.Jellyfin
+              ? ['Modified', 'Owner', 'Track Count', 'Visibility']
+              : []
+          }
         />
       )}
 
@@ -126,6 +134,9 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
             rowHeight: 'artistListRowHeight',
             fontSize: 'artistListFontSize',
           }}
+          disabledItemValues={
+            config.serverType === Server.Jellyfin ? ['Album Count', 'Rating'] : ['Duration']
+          }
         />
       )}
 
@@ -140,6 +151,9 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
             rowHeight: 'genreListRowHeight',
             fontSize: 'genreListFontSize',
           }}
+          disabledItemValues={
+            config.serverType === Server.Jellyfin ? ['Album Count', 'Track Count'] : []
+          }
         />
       )}
 
@@ -154,6 +168,7 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
             rowHeight: 'miniListRowHeight',
             fontSize: 'miniListFontSize',
           }}
+          disabledItemValues={config.serverType === Server.Jellyfin ? ['Path'] : []}
         />
       )}
 

--- a/src/components/shared/ColumnSort.tsx
+++ b/src/components/shared/ColumnSort.tsx
@@ -10,6 +10,7 @@ const ColumnSort = ({
   setSortType,
   setSortColumn,
   clearSortType,
+  disabledItemValues,
 }: any) => {
   const sortFilterPickerContainerRef = useRef<any>();
 
@@ -42,6 +43,7 @@ const ColumnSort = ({
           value={sortColumn}
           labelKey="label"
           valueKey="dataKey"
+          disabledItemValues={disabledItemValues}
           virtualized
           cleanable={false}
           style={{ width: '250px' }}

--- a/src/components/shared/styled.ts
+++ b/src/components/shared/styled.ts
@@ -303,6 +303,10 @@ export const StyledInputPickerContainer = styled.div`
     }
   }
 
+  .rs-picker-select-menu-item-disabled {
+    opacity: 0.5 !important;
+  }
+
   .rs-picker-select-menu-item-focus {
     color: ${(props) => props.theme.colors.input.color};
     background: ${(props) => props.theme.colors.input.backgroundHover};

--- a/src/components/starred/StarredView.tsx
+++ b/src/components/starred/StarredView.tsx
@@ -28,7 +28,7 @@ import { setActive, setSort } from '../../redux/favoriteSlice';
 import { apiController } from '../../api/controller';
 import { setPlaylistRate } from '../../redux/playlistSlice';
 import useColumnSort from '../../hooks/useColumnSort';
-import { Item } from '../../types';
+import { Item, Server } from '../../types';
 import { FilterButton } from '../shared/ToolbarButtons';
 import ColumnSortPopover from '../shared/ColumnSortPopover';
 
@@ -198,6 +198,15 @@ const StarredView = () => {
                     favorite.active.tab === 'albums'
                       ? favorite.active.album.sort.type
                       : favorite.active.artist.sort.type
+                  }
+                  disabledItemValues={
+                    config.serverType === Server.Jellyfin
+                      ? favorite.active.tab === 'albums'
+                        ? ['playCount', 'userRating']
+                        : ['albumCount', 'userRating']
+                      : favorite.active.tab === 'albums'
+                      ? []
+                      : ['duration']
                   }
                   clearSortType={() =>
                     dispatch(

--- a/src/components/viewtypes/ListViewTable.tsx
+++ b/src/components/viewtypes/ListViewTable.tsx
@@ -1058,6 +1058,12 @@ const ListViewTable = ({
                           ) : (
                             formatSongDuration(rowData[column.dataKey])
                           )
+                        ) : column.dataKey === 'public' ? (
+                          rowData[column.dataKey] ? (
+                            'Public'
+                          ) : (
+                            'Private'
+                          )
                         ) : column.dataKey === 'changed' || column.dataKey === 'created' ? (
                           <>
                             {rowData[column.dataKey] ? (

--- a/src/hooks/useColumnSort.ts
+++ b/src/hooks/useColumnSort.ts
@@ -39,14 +39,14 @@ const MUSIC_COLUMNS = [
 ];
 
 const PLAYLIST_COLUMNS = [
-  { label: 'Comment', dataKey: 'comment' },
   { label: 'Created', dataKey: 'created' },
+  { label: 'Description', dataKey: 'comment' },
   { label: 'Duration', dataKey: 'duration' },
-  { label: 'Modified', dataKey: 'modified' },
+  { label: 'Modified', dataKey: 'changed' },
   { label: 'Owner', dataKey: 'owner' },
-  { label: 'Public', dataKey: 'public' },
   { label: 'Song Count', dataKey: 'songCount' },
   { label: 'Title', dataKey: 'title' },
+  { label: 'Visibility', dataKey: 'public' },
 ];
 
 const GENRE_COLUMNS = [

--- a/src/hooks/useColumnSort.ts
+++ b/src/hooks/useColumnSort.ts
@@ -10,6 +10,7 @@ const ALBUM_COLUMNS = [
   { label: 'Duration', dataKey: 'duration' },
   { label: 'Favorite', dataKey: 'starred' },
   { label: 'Genre', dataKey: 'albumGenre' },
+  { label: 'Play Count', dataKey: 'playCount' },
   { label: 'Rating', dataKey: 'userRating' },
   { label: 'Song Count', dataKey: 'songCount' },
   { label: 'Title', dataKey: 'title' },

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export interface Album {
   albumArtistId: string;
   artist?: Artist[];
   songCount: number;
+  playCount?: number;
   duration: number;
   created: string;
   year?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,8 @@ export type APIEndpoints =
   | 'getMusicFolders'
   | 'getMusicDirectory'
   | 'getMusicDirectorySongs'
-  | 'getDownloadUrl';
+  | 'getDownloadUrl'
+  | 'getSongs';
 
 export interface GenericItem {
   id: string;


### PR DESCRIPTION
Closes #122 

- Adds initial API endpoint to fetch songs from Jellyfin
  - This will be used to eventually support a song-list view
- Adds support for songs as a grid-card (still plays the album on click)
- Fixes the recently played / most played sections on the dashboard for Jellyfin
  - Recently played now refetches data on 30s interval when on the page 
- Various other fixes for specific server types
  - Disable columns in the list-view column selector / filter selectors depending on server type
  - Fix the "visibility" column on list-view
  - Adds `Play Count` column to albums (Subsonic only / Navidrome)