### PR TITLE
Modernize config layout

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -20,7 +20,14 @@ import {
 import {
   GridViewConfigPanel,
   ListViewConfigPanel,
+  ThemeConfigPanel,
 } from '../settings/ConfigPanels/LookAndFeelConfig';
+import PlaybackConfig from '../settings/ConfigPanels/PlaybackConfig';
+import PlayerConfig from '../settings/ConfigPanels/PlayerConfig';
+import ServerConfig from '../settings/ConfigPanels/ServerConfig';
+import CacheConfig from '../settings/ConfigPanels/CacheConfig';
+import WindowConfig from '../settings/ConfigPanels/WindowConfig';
+import AdvancedConfig from '../settings/ConfigPanels/AdvancedConfig';
 
 const Layout = ({ footer, children, disableSidebar, font }: any) => {
   const history = useHistory();
@@ -211,17 +218,41 @@ const Layout = ({ footer, children, disableSidebar, font }: any) => {
                 </span>
                 <Whisper
                   speaker={
-                    <StyledPopover>
+                    <StyledPopover
+                      style={{
+                        maxWidth: '500px',
+                        maxHeight: '500px',
+                        overflowY: 'auto',
+                        overflowX: 'hidden',
+                        padding: '0px',
+                      }}
+                    >
                       <Nav
                         activeKey={activeConfigNav}
                         onSelect={(e) => setActiveConfigNav(e)}
                         appearance="tabs"
                       >
-                        <StyledNavItem eventKey="listView">List-View</StyledNavItem>
-                        <StyledNavItem eventKey="gridView">Grid-View</StyledNavItem>
+                        <StyledNavItem eventKey="listView">List View</StyledNavItem>
+                        <StyledNavItem eventKey="gridView">Grid View</StyledNavItem>
+                        <StyledNavItem eventKey="playback">Playback</StyledNavItem>
+                        <StyledNavItem eventKey="player">Player</StyledNavItem>
+                        <StyledNavItem eventKey="theme">Theme</StyledNavItem>
+                        <StyledNavItem eventKey="server">Server</StyledNavItem>
+                        <StyledNavItem eventKey="other">Other</StyledNavItem>
                       </Nav>
                       {activeConfigNav === 'listView' && <ListViewConfigPanel />}
                       {activeConfigNav === 'gridView' && <GridViewConfigPanel />}
+                      {activeConfigNav === 'playback' && <PlaybackConfig />}
+                      {activeConfigNav === 'player' && <PlayerConfig />}
+                      {activeConfigNav === 'theme' && <ThemeConfigPanel />}
+                      {activeConfigNav === 'server' && <ServerConfig />}
+                      {activeConfigNav === 'other' && (
+                        <>
+                          <CacheConfig />
+                          <WindowConfig />
+                          <AdvancedConfig />
+                        </>
+                      )}
                     </StyledPopover>
                   }
                   trigger="click"

--- a/src/components/settings/Config.tsx
+++ b/src/components/settings/Config.tsx
@@ -74,6 +74,8 @@ const Config = () => {
 
   return (
     <GenericPage
+      padding="20px"
+      hideDivider
       id="settings"
       header={
         <GenericPageHeader

--- a/src/components/settings/ConfigOption.tsx
+++ b/src/components/settings/ConfigOption.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { FlexboxGrid } from 'rsuite';
+import { ConfigOptionDescription, ConfigOptionName, ConfigOptionSection } from './styled';
+
+const ConfigOption = ({ name, description, option }: any) => {
+  return (
+    <ConfigOptionSection>
+      <FlexboxGrid justify="space-between" style={{ alignItems: 'center' }}>
+        <FlexboxGrid.Item style={{ maxWidth: '50%' }}>
+          <ConfigOptionName>{name}</ConfigOptionName>
+          <ConfigOptionDescription>{description}</ConfigOptionDescription>
+        </FlexboxGrid.Item>
+        <FlexboxGrid.Item>{option}</FlexboxGrid.Item>
+      </FlexboxGrid>
+    </ConfigOptionSection>
+  );
+};
+
+export default ConfigOption;

--- a/src/components/settings/ConfigPanels/AdvancedConfig.tsx
+++ b/src/components/settings/ConfigPanels/AdvancedConfig.tsx
@@ -3,9 +3,10 @@ import settings from 'electron-settings';
 import { Icon } from 'rsuite';
 import { shell } from 'electron';
 import { ConfigPanel } from '../styled';
-import { StyledButton, StyledCheckbox } from '../../shared/styled';
+import { StyledButton, StyledToggle } from '../../shared/styled';
 import { useAppDispatch } from '../../../redux/hooks';
 import { setPlaybackSetting } from '../../../redux/playQueueSlice';
+import ConfigOption from '../ConfigOption';
 
 const AdvancedConfig = () => {
   const dispatch = useAppDispatch();
@@ -15,34 +16,45 @@ const AdvancedConfig = () => {
   const [autoUpdate, setAutoUpdate] = useState(Boolean(settings.getSync('autoUpdate')));
 
   return (
-    <ConfigPanel header="Advanced" bordered>
-      <StyledCheckbox
-        defaultChecked={autoUpdate}
-        checked={autoUpdate}
-        onChange={(_v: any, e: boolean) => {
-          settings.setSync('autoUpdate', e);
-          setAutoUpdate(e);
-        }}
-      >
-        Auto update
-      </StyledCheckbox>
-      <StyledCheckbox
-        defaultChecked={showDebugWindow}
-        onChange={(_v: any, e: boolean) => {
-          settings.setSync('showDebugWindow', e);
-          dispatch(
-            setPlaybackSetting({
-              setting: 'showDebugWindow',
-              value: e,
-            })
-          );
-          setShowDebugWindow(e);
-        }}
-      >
-        Show debug window
-      </StyledCheckbox>
+    <ConfigPanel header="Advanced">
+      <ConfigOption
+        name="Automatic Updates"
+        description="Enables or disables automatic updates. When a new version is detected, it will automatically be downloaded and installed."
+        option={
+          <StyledToggle
+            defaultChecked={autoUpdate}
+            checked={autoUpdate}
+            onChange={(e: boolean) => {
+              settings.setSync('autoUpdate', e);
+              setAutoUpdate(e);
+            }}
+          />
+        }
+      />
+
+      <ConfigOption
+        name="Show Debug Window"
+        description="Displays the debug window."
+        option={
+          <StyledToggle
+            defaultChecked={showDebugWindow}
+            checked={showDebugWindow}
+            onChange={(e: boolean) => {
+              settings.setSync('showDebugWindow', e);
+              dispatch(
+                setPlaybackSetting({
+                  setting: 'showDebugWindow',
+                  value: e,
+                })
+              );
+              setShowDebugWindow(e);
+            }}
+          />
+        }
+      />
+
       <br />
-      <StyledButton onClick={() => shell.openPath(settings.file())}>
+      <StyledButton appearance="primary" onClick={() => shell.openPath(settings.file())}>
         Open settings JSON <Icon icon="external-link" />
       </StyledButton>
     </ConfigPanel>

--- a/src/components/settings/ConfigPanels/CacheConfig.tsx
+++ b/src/components/settings/ConfigPanels/CacheConfig.tsx
@@ -4,7 +4,7 @@ import { shell } from 'electron';
 import fs from 'fs';
 import path from 'path';
 import { Message, Icon, ButtonToolbar, Whisper } from 'rsuite';
-import { ConfigPanel } from '../styled';
+import { ConfigOptionDescription, ConfigPanel } from '../styled';
 import {
   StyledInput,
   StyledCheckbox,
@@ -104,18 +104,18 @@ const CacheConfig = () => {
   };
 
   return (
-    <ConfigPanel header="Cache" bordered>
+    <ConfigPanel header="Cache">
       {errorMessage !== '' && (
         <>
           <Message showIcon type="error" description={errorMessage} />
           <br />
         </>
       )}
-      <p>
+      <ConfigOptionDescription>
         Songs are cached only when playback for the track fully completes and ends. Skipping to the
         next or previous track after only partially completing the track will not begin the caching
         process.
-      </p>
+      </ConfigOptionDescription>
       <br />
       {isEditingCachePath && (
         <>

--- a/src/components/settings/ConfigPanels/ListViewConfig.tsx
+++ b/src/components/settings/ConfigPanels/ListViewConfig.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { nanoid } from 'nanoid/non-secure';
 import settings from 'electron-settings';
-import { ControlLabel } from 'rsuite';
 import {
+  StyledCheckPicker,
   StyledInputNumber,
   StyledInputPickerContainer,
   StyledPanel,
-  StyledTagPicker,
 } from '../../shared/styled';
 import ListViewTable from '../../viewtypes/ListViewTable';
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
@@ -23,6 +22,7 @@ import {
   setFontSize,
   setRowHeight,
 } from '../../../redux/configSlice';
+import ConfigOption from '../ConfigOption';
 
 const columnSelectorColumns = [
   {
@@ -52,6 +52,7 @@ const columnSelectorColumns = [
 ];
 
 const ListViewConfig = ({
+  type,
   defaultColumns,
   columnPicker,
   columnList,
@@ -62,7 +63,7 @@ const ListViewConfig = ({
   const playQueue = useAppSelector((state) => state.playQueue);
   const multiSelect = useAppSelector((state) => state.multiSelect);
   const config = useAppSelector((state) => state.config);
-  const [selectedColumns, setSelectedColumns] = useState([]);
+  const [selectedColumns, setSelectedColumns] = useState<any[]>([]);
   const columnListType = settingsConfig.columnList.split('List')[0];
   const columnPickerContainerRef = useRef(null);
 
@@ -111,15 +112,20 @@ const ListViewConfig = ({
   return (
     <div style={{ width: '100%' }}>
       <div>
-        <StyledPanel bordered bodyFill>
+        <StyledPanel>
           <StyledInputPickerContainer ref={columnPickerContainerRef}>
-            <StyledTagPicker
+            <StyledCheckPicker
               container={() => columnPickerContainerRef.current}
               data={columnPicker}
               defaultValue={defaultColumns}
               value={selectedColumns}
-              disabledItemValues={disabledItemValues}
+              disabledItemValues={disabledItemValues.filter((col: string) => {
+                return !selectedColumns.includes(col);
+              })}
+              sticky
+              searchable={false}
               style={{ width: '100%' }}
+              maxHeight={250}
               onChange={(e: any) => {
                 const columns: any[] = [];
                 if (e) {
@@ -161,10 +167,9 @@ const ListViewConfig = ({
               valueKey="label"
             />
           </StyledInputPickerContainer>
-
           <ListViewTable
             data={config.lookAndFeel.listView[columnListType].columns || []}
-            height={300}
+            height={200}
             handleRowClick={handleRowClick}
             handleRowDoubleClick={() => {}}
             handleDragEnd={() => handleDragEnd(columnListType)}
@@ -182,39 +187,45 @@ const ListViewConfig = ({
             config={{ option: columnListType, columnList }}
             virtualized
           />
+          <p style={{ fontSize: 'smaller' }}>* Drag & drop rows to re-order</p>
         </StyledPanel>
       </div>
 
-      <br />
-      <div>
-        <ControlLabel>Row height</ControlLabel>
-        <StyledInputNumber
-          defaultValue={config.lookAndFeel.listView[columnListType]?.rowHeight || 40}
-          step={1}
-          min={15}
-          max={250}
-          width={150}
-          onChange={(e: number) => {
-            settings.setSync(settingsConfig.rowHeight, Number(e));
-            dispatch(setRowHeight({ listType: columnListType, height: Number(e) }));
-          }}
-        />
-      </div>
-      <br />
-      <div>
-        <ControlLabel>Font size</ControlLabel>
-        <StyledInputNumber
-          defaultValue={config.lookAndFeel.listView[columnListType]?.fontSize || 12}
-          step={0.5}
-          min={1}
-          max={100}
-          width={150}
-          onChange={(e: number) => {
-            settings.setSync(settingsConfig.fontSize, Number(e));
-            dispatch(setFontSize({ listType: columnListType, size: Number(e) }));
-          }}
-        />
-      </div>
+      <ConfigOption
+        name={`Row Height (${type})`}
+        description="The height in pixels (px) of each row in the list view."
+        option={
+          <StyledInputNumber
+            defaultValue={config.lookAndFeel.listView[columnListType]?.rowHeight || 40}
+            step={1}
+            min={15}
+            max={250}
+            width={125}
+            onChange={(e: number) => {
+              settings.setSync(settingsConfig.rowHeight, Number(e));
+              dispatch(setRowHeight({ listType: columnListType, height: Number(e) }));
+            }}
+          />
+        }
+      />
+
+      <ConfigOption
+        name={`Font Size (${type})`}
+        description="The height in pixels (px) of each row in the list view."
+        option={
+          <StyledInputNumber
+            defaultValue={config.lookAndFeel.listView[columnListType]?.fontSize || 12}
+            step={0.5}
+            min={1}
+            max={100}
+            width={125}
+            onChange={(e: number) => {
+              settings.setSync(settingsConfig.fontSize, Number(e));
+              dispatch(setFontSize({ listType: columnListType, size: Number(e) }));
+            }}
+          />
+        }
+      />
     </div>
   );
 };

--- a/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
+++ b/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
@@ -2,18 +2,18 @@ import React, { useRef, useState } from 'react';
 import _ from 'lodash';
 import { shell } from 'electron';
 import settings from 'electron-settings';
-import { ControlLabel, Nav, Icon, RadioGroup } from 'rsuite';
+import { Nav, Icon, RadioGroup } from 'rsuite';
 import { ConfigPanel } from '../styled';
 import {
   StyledInputPicker,
   StyledNavItem,
   StyledInputNumber,
-  StyledCheckbox,
   StyledInputPickerContainer,
   StyledLink,
   StyledInputGroup,
-  StyledInputGroupButton,
   StyledRadio,
+  StyledIconButton,
+  StyledToggle,
 } from '../../shared/styled';
 import ListViewConfig from './ListViewConfig';
 import { Fonts } from '../Fonts';
@@ -38,6 +38,7 @@ import {
   setGridGapSize,
 } from '../../../redux/configSlice';
 import { Server } from '../../../types';
+import ConfigOption from '../ConfigOption';
 
 export const ListViewConfigPanel = ({ bordered }: any) => {
   const dispatch = useAppDispatch();
@@ -62,7 +63,7 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
   const currentGenreColumns = genreCols?.map((column: any) => column.label) || [];
 
   return (
-    <ConfigPanel header="List-View" bordered={bordered}>
+    <ConfigPanel header="List View" bordered={bordered}>
       <Nav
         activeKey={config.active.columnSelectorTab}
         onSelect={(e) => dispatch(setActive({ ...config.active, columnSelectorTab: e }))}
@@ -76,7 +77,7 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
       </Nav>
       {config.active.columnSelectorTab === 'music' && (
         <ListViewConfig
-          title="Song List"
+          type="Songs"
           defaultColumns={currentSongColumns}
           columnPicker={songColumnPicker}
           columnList={songColumnListAuto}
@@ -91,7 +92,7 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
 
       {config.active.columnSelectorTab === 'album' && (
         <ListViewConfig
-          title="Album List"
+          type="Albums"
           defaultColumns={currentAlbumColumns}
           columnPicker={albumColumnPicker}
           columnList={albumColumnListAuto}
@@ -106,7 +107,7 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
 
       {config.active.columnSelectorTab === 'playlist' && (
         <ListViewConfig
-          title="Playlist List"
+          type="Playlists"
           defaultColumns={currentPlaylistColumns}
           columnPicker={playlistColumnPicker}
           columnList={playlistColumnListAuto}
@@ -125,7 +126,7 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
 
       {config.active.columnSelectorTab === 'artist' && (
         <ListViewConfig
-          title="Artist List"
+          type="Artists"
           defaultColumns={currentArtistColumns}
           columnPicker={artistColumnPicker}
           columnList={artistColumnListAuto}
@@ -142,7 +143,7 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
 
       {config.active.columnSelectorTab === 'genre' && (
         <ListViewConfig
-          title="Genre List"
+          type="Genres"
           defaultColumns={currentGenreColumns}
           columnPicker={genreColumnPicker}
           columnList={genreColumnListAuto}
@@ -159,7 +160,7 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
 
       {config.active.columnSelectorTab === 'mini' && (
         <ListViewConfig
-          title="Miniplayer List"
+          type="Mini-player"
           defaultColumns={currentMiniColumns}
           columnPicker={songColumnPicker}
           columnList={songColumnListAuto}
@@ -172,23 +173,26 @@ export const ListViewConfigPanel = ({ bordered }: any) => {
         />
       )}
 
-      <br />
-      <StyledCheckbox
-        defaultChecked={highlightOnRowHoverChk}
-        checked={highlightOnRowHoverChk}
-        onChange={(_v: any, e: boolean) => {
-          settings.setSync('highlightOnRowHover', e);
-          dispatch(
-            setMiscSetting({
-              setting: 'highlightOnRowHover',
-              value: e,
-            })
-          );
-          setHighlightOnRowHoverChk(e);
-        }}
-      >
-        Show highlight on row hover
-      </StyledCheckbox>
+      <ConfigOption
+        name="Highlight On Hover"
+        description="Highlights the list view row when hovering it with the mouse."
+        option={
+          <StyledToggle
+            defaultChecked={highlightOnRowHoverChk}
+            checked={highlightOnRowHoverChk}
+            onChange={(e: boolean) => {
+              settings.setSync('highlightOnRowHover', e);
+              dispatch(
+                setMiscSetting({
+                  setting: 'highlightOnRowHover',
+                  value: e,
+                })
+              );
+              setHighlightOnRowHoverChk(e);
+            }}
+          />
+        }
+      />
     </ConfigPanel>
   );
 };
@@ -199,51 +203,66 @@ export const GridViewConfigPanel = ({ bordered }: any) => {
 
   return (
     <ConfigPanel header="Grid-View" bordered={bordered}>
-      <ControlLabel>Card size (px)</ControlLabel>
-      <StyledInputNumber
-        defaultValue={config.lookAndFeel.gridView.cardSize}
-        step={1}
-        min={100}
-        max={350}
-        width={150}
-        onChange={(e: any) => {
-          settings.setSync('gridCardSize', Number(e));
-          dispatch(setGridCardSize({ size: Number(e) }));
-        }}
+      <ConfigOption
+        name="Card Size"
+        description="The width and height in pixels (px) of each grid view card."
+        option={
+          <StyledInputNumber
+            defaultValue={config.lookAndFeel.gridView.cardSize}
+            step={1}
+            min={100}
+            max={350}
+            width={125}
+            onChange={(e: any) => {
+              settings.setSync('gridCardSize', Number(e));
+              dispatch(setGridCardSize({ size: Number(e) }));
+            }}
+          />
+        }
       />
-      <br />
-      <ControlLabel>Gap size (px)</ControlLabel>
-      <StyledInputNumber
-        defaultValue={config.lookAndFeel.gridView.gapSize}
-        step={1}
-        min={0}
-        max={100}
-        width={150}
-        onChange={(e: any) => {
-          settings.setSync('gridGapSize', Number(e));
-          dispatch(setGridGapSize({ size: Number(e) }));
-        }}
+
+      <ConfigOption
+        name="Gap Size"
+        description="The gap in pixels (px) of the grid view layout."
+        option={
+          <StyledInputNumber
+            defaultValue={config.lookAndFeel.gridView.gapSize}
+            step={1}
+            min={0}
+            max={100}
+            width={125}
+            onChange={(e: any) => {
+              settings.setSync('gridGapSize', Number(e));
+              dispatch(setGridGapSize({ size: Number(e) }));
+            }}
+          />
+        }
       />
-      <br />
-      <ControlLabel>Grid alignment</ControlLabel>
-      <RadioGroup
-        name="gridAlignemntRadioList"
-        appearance="default"
-        defaultValue={config.lookAndFeel.gridView.alignment}
-        value={config.lookAndFeel.gridView.alignment}
-        onChange={(e: string) => {
-          dispatch(setGridAlignment({ alignment: e }));
-          settings.setSync('gridAlignment', e);
-        }}
-      >
-        <StyledRadio value="flex-start">Left</StyledRadio>
-        <StyledRadio value="center">Center</StyledRadio>
-      </RadioGroup>
+
+      <ConfigOption
+        name="Grid Alignment"
+        description="The alignment of cards in the grid view layout."
+        option={
+          <RadioGroup
+            name="gridAlignemntRadioList"
+            inline
+            defaultValue={config.lookAndFeel.gridView.alignment}
+            value={config.lookAndFeel.gridView.alignment}
+            onChange={(e: string) => {
+              dispatch(setGridAlignment({ alignment: e }));
+              settings.setSync('gridAlignment', e);
+            }}
+          >
+            <StyledRadio value="flex-start">Left</StyledRadio>
+            <StyledRadio value="center">Center</StyledRadio>
+          </RadioGroup>
+        }
+      />
     </ConfigPanel>
   );
 };
 
-const LookAndFeelConfig = () => {
+export const ThemeConfigPanel = ({ bordered }: any) => {
   const dispatch = useAppDispatch();
   const [dynamicBackgroundChk, setDynamicBackgroundChk] = useState(
     Boolean(settings.getSync('dynamicBackground'))
@@ -258,34 +277,14 @@ const LookAndFeelConfig = () => {
   );
 
   return (
-    <>
-      <ConfigPanel header="Look & Feel" bordered>
-        <p>
-          <StyledLink
-            onClick={() => shell.openExternal('https://github.com/jeffvli/sonixd/discussions/61')}
-          >
-            Check out the theming documentation! <Icon icon="external-link" />
-          </StyledLink>
-        </p>
-        <br />
-        <StyledInputPickerContainer ref={themePickerContainerRef}>
-          <ControlLabel>Theme</ControlLabel>
-          <br />
-          <StyledInputGroup>
-            <StyledInputPicker
-              container={() => themePickerContainerRef.current}
-              data={themeList}
-              labelKey="label"
-              valueKey="value"
-              cleanable={false}
-              defaultValue={selectedTheme}
-              onChange={(e: string) => {
-                settings.setSync('theme', e);
-                setSelectedTheme(e);
-                dispatch(setTheme(e));
-              }}
-            />
-            <StyledInputGroupButton
+    <ConfigPanel header="Look & Feel" bordered={bordered}>
+      <ConfigOption
+        name={
+          <>
+            Theme{' '}
+            <StyledIconButton
+              size="xs"
+              icon={<Icon icon="refresh" />}
               onClick={() => {
                 dispatch(setTheme('defaultDark'));
                 dispatch(setTheme(selectedTheme));
@@ -293,67 +292,117 @@ const LookAndFeelConfig = () => {
                   _.concat(settings.getSync('themes'), settings.getSync('themesDefault'))
                 );
               }}
+            />
+          </>
+        }
+        description={
+          <>
+            The application theme. Want to create your own themes? Check out the documentation{' '}
+            <StyledLink
+              onClick={() => shell.openExternal('https://github.com/jeffvli/sonixd/discussions/61')}
             >
-              <Icon icon="refresh" />
-            </StyledInputGroupButton>
-          </StyledInputGroup>
-        </StyledInputPickerContainer>
-        <br />
-        <StyledInputPickerContainer ref={fontPickerContainerRef}>
-          <ControlLabel>Font</ControlLabel>
-          <br />
-          <StyledInputPicker
-            container={() => fontPickerContainerRef.current}
-            data={Fonts}
-            groupBy="role"
-            cleanable={false}
-            defaultValue={String(settings.getSync('font'))}
-            onChange={(e: string) => {
-              settings.setSync('font', e);
-              dispatch(setFont(e));
-            }}
-          />
-        </StyledInputPickerContainer>
-        <br />
-        <StyledInputPickerContainer ref={titleBarPickerContainerRef}>
-          <ControlLabel>Titlebar style (requires app restart)</ControlLabel>
-          <br />
-          <StyledInputPicker
-            container={() => titleBarPickerContainerRef.current}
-            data={[
-              {
-                label: 'macOS',
-                value: 'mac',
-              },
-              {
-                label: 'Windows',
-                value: 'windows',
-              },
-            ]}
-            cleanable={false}
-            defaultValue={String(settings.getSync('titleBarStyle'))}
-            onChange={(e: string) => {
-              settings.setSync('titleBarStyle', e);
-              dispatch(setMiscSetting({ setting: 'titleBar', value: e }));
-            }}
-          />
-        </StyledInputPickerContainer>
-        <br />
-        <StyledCheckbox
-          defaultChecked={dynamicBackgroundChk}
-          checked={dynamicBackgroundChk}
-          onChange={(_v: any, e: boolean) => {
-            settings.setSync('dynamicBackground', e);
-            dispatch(setDynamicBackground(e));
-            setDynamicBackgroundChk(e);
-          }}
-        >
-          Enable dynamic background
-        </StyledCheckbox>
-      </ConfigPanel>
+              here
+            </StyledLink>
+            .
+          </>
+        }
+        option={
+          <StyledInputPickerContainer ref={themePickerContainerRef}>
+            <StyledInputGroup>
+              <StyledInputPicker
+                container={() => themePickerContainerRef.current}
+                data={themeList}
+                labelKey="label"
+                valueKey="value"
+                cleanable={false}
+                width={200}
+                defaultValue={selectedTheme}
+                onChange={(e: string) => {
+                  settings.setSync('theme', e);
+                  setSelectedTheme(e);
+                  dispatch(setTheme(e));
+                }}
+              />
+            </StyledInputGroup>
+          </StyledInputPickerContainer>
+        }
+      />
 
-      <ListViewConfigPanel bordered />
-      <GridViewConfigPanel bordered />
+      <ConfigOption
+        name="Font"
+        description="The application font."
+        option={
+          <StyledInputPickerContainer ref={fontPickerContainerRef}>
+            <StyledInputPicker
+              container={() => fontPickerContainerRef.current}
+              data={Fonts}
+              groupBy="role"
+              width={200}
+              cleanable={false}
+              defaultValue={String(settings.getSync('font'))}
+              onChange={(e: string) => {
+                settings.setSync('font', e);
+                dispatch(setFont(e));
+              }}
+            />
+          </StyledInputPickerContainer>
+        }
+      />
+
+      <ConfigOption
+        name="Titlebar Style"
+        description="The titlebar style (requires app restart). "
+        option={
+          <StyledInputPickerContainer ref={titleBarPickerContainerRef}>
+            <StyledInputPicker
+              container={() => titleBarPickerContainerRef.current}
+              data={[
+                {
+                  label: 'macOS',
+                  value: 'mac',
+                },
+                {
+                  label: 'Windows',
+                  value: 'windows',
+                },
+              ]}
+              cleanable={false}
+              defaultValue={String(settings.getSync('titleBarStyle'))}
+              width={200}
+              onChange={(e: string) => {
+                settings.setSync('titleBarStyle', e);
+                dispatch(setMiscSetting({ setting: 'titleBar', value: e }));
+              }}
+            />
+          </StyledInputPickerContainer>
+        }
+      />
+
+      <ConfigOption
+        name="Dynamic Background"
+        description="Sets a dynamic background based on the currently playing song."
+        option={
+          <StyledToggle
+            defaultChecked={dynamicBackgroundChk}
+            checked={dynamicBackgroundChk}
+            onChange={(e: boolean) => {
+              settings.setSync('dynamicBackground', e);
+              dispatch(setDynamicBackground(e));
+              setDynamicBackgroundChk(e);
+            }}
+          />
+        }
+      />
+    </ConfigPanel>
+  );
+};
+
+const LookAndFeelConfig = () => {
+  return (
+    <>
+      <ThemeConfigPanel />
+      <ListViewConfigPanel />
+      <GridViewConfigPanel />
     </>
   );
 };

--- a/src/components/settings/ConfigPanels/PlaybackConfig.tsx
+++ b/src/components/settings/ConfigPanels/PlaybackConfig.tsx
@@ -1,16 +1,17 @@
 import React, { useRef, useState } from 'react';
 import settings from 'electron-settings';
-import { ButtonToolbar, ControlLabel, RadioGroup } from 'rsuite';
+import { ButtonToolbar } from 'rsuite';
 import { ConfigPanel } from '../styled';
 import {
   StyledButton,
   StyledInputNumber,
   StyledInputPicker,
   StyledInputPickerContainer,
-  StyledRadio,
+  StyledToggle,
 } from '../../shared/styled';
 import { useAppDispatch } from '../../../redux/hooks';
 import { setPlaybackSetting } from '../../../redux/playQueueSlice';
+import ConfigOption from '../ConfigOption';
 
 const PlaybackConfig = () => {
   const dispatch = useAppDispatch();
@@ -52,151 +53,136 @@ const PlaybackConfig = () => {
   };
 
   return (
-    <ConfigPanel header="Playback" bordered>
-      <p>
-        Fading works by polling the audio player on an interval to determine when to start fading to
-        the next track. Due to this, you may notice the fade timing may not be 100% perfect.
-        Lowering the player polling interval may increase the accuracy of the fade, but also
-        increases the application&apos;s CPU usage.
-      </p>
-
-      <p>
-        Setting the crossfade duration to <code>0</code> will enable{' '}
-        <strong>gapless playback</strong> mode. All other playback settings except the polling
-        interval will be ignored. It is recommended that you use a polling interval between{' '}
-        <code>10</code> and <code>20</code> for increased transition accuracy. Note that the gapless
-        playback is not true gapless and may work better or worse on specific albums.
-      </p>
-
-      <p>
-        If volume fade is disabled, then the fading-in track will start at the specified crossfade
-        duration at full volume.
-      </p>
-
-      <p style={{ fontSize: 'smaller' }}>
-        *Enable the debug window if you want to view the differences between each fade type
-      </p>
-
-      <div style={{ paddingTop: '20px' }}>
-        <ControlLabel>Crossfade duration (s)</ControlLabel>
-        <StyledInputNumber
-          defaultValue={crossfadeDuration}
-          value={crossfadeDuration}
-          step={0.05}
-          min={0}
-          max={100}
-          width={150}
-          onChange={(e: number) => handleSetCrossfadeDuration(e)}
+    <>
+      <ConfigPanel header="Playback">
+        <ConfigOption
+          name="Crossfade Duration (s)"
+          description="The number in seconds before starting the crossfade to the next track. Setting this to 0 will enable gapless playback."
+          option={
+            <StyledInputNumber
+              defaultValue={crossfadeDuration}
+              value={crossfadeDuration}
+              step={0.05}
+              min={0}
+              max={100}
+              width={125}
+              onChange={(e: number) => handleSetCrossfadeDuration(e)}
+            />
+          }
         />
 
-        <br />
-        <ControlLabel>Polling interval (ms)</ControlLabel>
-        <StyledInputNumber
-          defaultValue={pollingInterval}
-          value={pollingInterval}
-          step={1}
-          min={1}
-          max={1000}
-          width={150}
-          onChange={(e: number) => handleSetPollingInterval(e)}
+        <ConfigOption
+          name="Polling Interval"
+          description="The number in milliseconds between each poll when music is playing. This is used in the calculation for crossfading and gapless playback. Recommended value for gapless playback is between 10 and 20."
+          option={
+            <StyledInputNumber
+              defaultValue={pollingInterval}
+              value={pollingInterval}
+              step={1}
+              min={1}
+              max={1000}
+              width={125}
+              onChange={(e: number) => handleSetPollingInterval(e)}
+            />
+          }
         />
-        <br />
-        <StyledInputPickerContainer ref={crossfadePickerContainerRef}>
-          <ControlLabel>Crossfade type</ControlLabel>
-          <br />
-          <StyledInputPicker
-            container={() => crossfadePickerContainerRef.current}
-            data={[
-              {
-                label: 'Equal Power',
-                value: 'equalPower',
-              },
-              {
-                label: 'Linear',
-                value: 'linear',
-              },
-              {
-                label: 'Dipped',
-                value: 'dipped',
-              },
-              {
-                label: 'Constant Power',
-                value: 'constantPower',
-              },
-              {
-                label: 'Constant Power (slow fade)',
-                value: 'constantPowerSlowFade',
-              },
-              {
-                label: 'Constant Power (slow cut)',
-                value: 'constantPowerSlowCut',
-              },
-              {
-                label: 'Constant Power (fast cut)',
-                value: 'constantPowerFastCut',
-              },
-            ]}
-            cleanable={false}
-            defaultValue={String(settings.getSync('fadeType'))}
-            onChange={(e: string) => {
-              settings.setSync('fadeType', e);
-              dispatch(setPlaybackSetting({ setting: 'fadeType', value: e }));
-            }}
-          />
-        </StyledInputPickerContainer>
 
-        <br />
-        <ControlLabel>Volume fade</ControlLabel>
-        <RadioGroup
-          name="volumeFadeRadioList"
-          appearance="default"
-          defaultValue={volumeFade}
-          value={volumeFade}
-          onChange={(e: boolean) => handleSetVolumeFade(e)}
-        >
-          <StyledRadio value>Enabled</StyledRadio>
-          <StyledRadio value={false}>Disabled</StyledRadio>
-        </RadioGroup>
-        <br />
-        <h6>Presets</h6>
-        <ButtonToolbar>
-          <StyledButton
-            onClick={() => {
-              setCrossfadeDuration(0);
-              setPollingInterval(15);
-              handleSetCrossfadeDuration(0);
-              handleSetPollingInterval(15);
-            }}
-          >
-            Gapless
-          </StyledButton>
-          <StyledButton
-            onClick={() => {
-              setCrossfadeDuration(7);
-              setPollingInterval(50);
-              setVolumeFade(true);
-              handleSetCrossfadeDuration(7);
-              handleSetPollingInterval(50);
-              handleSetVolumeFade(true);
-            }}
-          >
-            Fade
-          </StyledButton>
-          <StyledButton
-            onClick={() => {
-              setCrossfadeDuration(0);
-              setPollingInterval(200);
-              setVolumeFade(false);
-              handleSetCrossfadeDuration(0);
-              handleSetPollingInterval(200);
-              handleSetVolumeFade(false);
-            }}
-          >
-            Normal
-          </StyledButton>
-        </ButtonToolbar>
-      </div>
-    </ConfigPanel>
+        <ConfigOption
+          name="Crossfade Type"
+          description="The fade calculation to use when crossfading between two tracks. Enable the debug window to view the differences between each fade type."
+          option={
+            <StyledInputPickerContainer ref={crossfadePickerContainerRef}>
+              <StyledInputPicker
+                container={() => crossfadePickerContainerRef.current}
+                data={[
+                  {
+                    label: 'Equal Power',
+                    value: 'equalPower',
+                  },
+                  {
+                    label: 'Linear',
+                    value: 'linear',
+                  },
+                  {
+                    label: 'Dipped',
+                    value: 'dipped',
+                  },
+                  {
+                    label: 'Constant Power',
+                    value: 'constantPower',
+                  },
+                  {
+                    label: 'Constant Power (slow fade)',
+                    value: 'constantPowerSlowFade',
+                  },
+                  {
+                    label: 'Constant Power (slow cut)',
+                    value: 'constantPowerSlowCut',
+                  },
+                  {
+                    label: 'Constant Power (fast cut)',
+                    value: 'constantPowerFastCut',
+                  },
+                ]}
+                cleanable={false}
+                defaultValue={String(settings.getSync('fadeType'))}
+                onChange={(e: string) => {
+                  settings.setSync('fadeType', e);
+                  dispatch(setPlaybackSetting({ setting: 'fadeType', value: e }));
+                }}
+                width={200}
+              />
+            </StyledInputPickerContainer>
+          }
+        />
+
+        <ConfigOption
+          name="Volume Fade"
+          description="Enable or disable the volume fade used by the crossfading players. If disabled, the fading in track will start at full volume."
+          option={
+            <StyledToggle
+              size="md"
+              defaultChecked={volumeFade}
+              checked={volumeFade}
+              onChange={(e: boolean) => handleSetVolumeFade(e)}
+            />
+          }
+        />
+
+        <ConfigOption
+          name="Playback Presets"
+          description="Don't know where to start? Apply a preset and tweak from there."
+          option={
+            <ButtonToolbar>
+              <StyledButton
+                width={100}
+                onClick={() => {
+                  setCrossfadeDuration(0);
+                  setPollingInterval(15);
+                  handleSetCrossfadeDuration(0);
+                  handleSetPollingInterval(15);
+                }}
+              >
+                Gapless
+              </StyledButton>
+              <StyledButton
+                width={100}
+                onClick={() => {
+                  setCrossfadeDuration(7);
+                  setPollingInterval(50);
+                  setVolumeFade(true);
+                  handleSetCrossfadeDuration(7);
+                  handleSetPollingInterval(50);
+                  handleSetVolumeFade(true);
+                }}
+              >
+                Fade
+              </StyledButton>
+            </ButtonToolbar>
+          }
+        />
+      </ConfigPanel>
+    </>
   );
 };
 

--- a/src/components/settings/ConfigPanels/PlayerConfig.tsx
+++ b/src/components/settings/ConfigPanels/PlayerConfig.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { shell } from 'electron';
+import { ipcRenderer, shell } from 'electron';
 import settings from 'electron-settings';
 import { Form } from 'rsuite';
 import { ConfigOptionDescription, ConfigOptionName, ConfigPanel } from '../styled';
@@ -167,6 +167,11 @@ const PlayerConfig = () => {
             onChange={(e: boolean) => {
               settings.setSync('globalMediaHotkeys', e);
               setGlobalMediaHotkeys(e);
+              if (e) {
+                ipcRenderer.send('enableGlobalHotkeys');
+              } else {
+                ipcRenderer.send('disableGlobalHotkeys');
+              }
             }}
           />
         }

--- a/src/components/settings/ConfigPanels/ServerConfig.tsx
+++ b/src/components/settings/ConfigPanels/ServerConfig.tsx
@@ -2,13 +2,14 @@ import React, { useRef } from 'react';
 import settings from 'electron-settings';
 import { useQuery } from 'react-query';
 import { CheckboxGroup } from 'rsuite';
-import { ConfigPanel } from '../styled';
+import { ConfigOptionDescription, ConfigOptionInput, ConfigPanel } from '../styled';
 import { StyledCheckbox, StyledInputPicker, StyledInputPickerContainer } from '../../shared/styled';
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
 import { setAppliedFolderViews, setMusicFolder } from '../../../redux/folderSlice';
 import { apiController } from '../../../api/controller';
 import { Folder } from '../../../types';
 import PageLoader from '../../loader/PageLoader';
+import ConfigOption from '../ConfigOption';
 
 const ServerConfig = () => {
   const dispatch = useAppDispatch();
@@ -24,31 +25,34 @@ const ServerConfig = () => {
   }
 
   return (
-    <ConfigPanel header="Server" bordered>
-      <p>
-        Select a music folder (leaving this blank will use all folders). If no songs are found in
-        the music folder, you may need to rescan your library.
-      </p>
-      <br />
-      <StyledInputPickerContainer ref={musicFolderPickerContainerRef}>
-        <StyledInputPicker
-          container={() => musicFolderPickerContainerRef.current}
-          data={musicFolders}
-          defaultValue={folder.musicFolder}
-          valueKey="id"
-          labelKey="title"
-          onChange={(e: string) => {
-            const selectedFolder = musicFolders.find((f: Folder) => f.id === e);
-            settings.setSync('musicFolder.id', e);
-            settings.setSync('musicFolder.name', selectedFolder?.title);
-            dispatch(setMusicFolder({ id: e, name: selectedFolder?.title }));
-          }}
-        />
-      </StyledInputPickerContainer>
+    <ConfigPanel header="Server">
+      <ConfigOption
+        name="Media Folder"
+        description="Sets the parent media folder your audio files are located in. Leaving this blank will use all media folders."
+        option={
+          <StyledInputPickerContainer ref={musicFolderPickerContainerRef}>
+            <StyledInputPicker
+              container={() => musicFolderPickerContainerRef.current}
+              data={musicFolders}
+              defaultValue={folder.musicFolder}
+              valueKey="id"
+              labelKey="title"
+              width={200}
+              onChange={(e: string) => {
+                const selectedFolder = musicFolders.find((f: Folder) => f.id === e);
+                settings.setSync('musicFolder.id', e);
+                settings.setSync('musicFolder.name', selectedFolder?.title);
+                dispatch(setMusicFolder({ id: e, name: selectedFolder?.title }));
+              }}
+            />
+          </StyledInputPickerContainer>
+        }
+      />
 
-      <div>
-        <br />
-        <p>Select which pages to apply music folder filtering to:</p>
+      <ConfigOptionDescription>
+        Select which pages to apply media folder filtering to:
+      </ConfigOptionDescription>
+      <ConfigOptionInput>
         <CheckboxGroup>
           <StyledCheckbox
             defaultChecked={folder.applied.albums}
@@ -96,7 +100,7 @@ const ServerConfig = () => {
             Search
           </StyledCheckbox>
         </CheckboxGroup>
-      </div>
+      </ConfigOptionInput>
     </ConfigPanel>
   );
 };

--- a/src/components/settings/ConfigPanels/WindowConfig.tsx
+++ b/src/components/settings/ConfigPanels/WindowConfig.tsx
@@ -1,35 +1,47 @@
 import React, { useState } from 'react';
 import settings from 'electron-settings';
-import { ConfigPanel } from '../styled';
-import { StyledCheckbox } from '../../shared/styled';
+import { ConfigOptionDescription, ConfigPanel } from '../styled';
+import { StyledToggle } from '../../shared/styled';
+import ConfigOption from '../ConfigOption';
 
 const WindowConfig = () => {
   const [minimizeToTray, setMinimizeToTray] = useState(Boolean(settings.getSync('minimizeToTray')));
   const [exitToTray, setExitToTray] = useState(Boolean(settings.getSync('exitToTray')));
   return (
-    <ConfigPanel header="Window" bordered>
-      <p>Note: These settings may not function correctly depending on your desktop environment.</p>
-      <StyledCheckbox
-        defaultChecked={minimizeToTray}
-        checked={minimizeToTray}
-        onChange={(_v: any, e: boolean) => {
-          settings.setSync('minimizeToTray', e);
-          setMinimizeToTray(e);
-        }}
-      >
-        Minimize to tray
-      </StyledCheckbox>
+    <ConfigPanel header="Window">
+      <ConfigOptionDescription>
+        Note: These settings may not function correctly depending on your desktop environment.
+      </ConfigOptionDescription>
 
-      <StyledCheckbox
-        defaultChecked={exitToTray}
-        checked={exitToTray}
-        onChange={(_v: any, e: boolean) => {
-          settings.setSync('exitToTray', e);
-          setExitToTray(e);
-        }}
-      >
-        Exit to tray
-      </StyledCheckbox>
+      <ConfigOption
+        name="Minimize to Tray"
+        description="Minimizes to the system tray."
+        option={
+          <StyledToggle
+            defaultChecked={minimizeToTray}
+            checked={minimizeToTray}
+            onChange={(e: boolean) => {
+              settings.setSync('minimizeToTray', e);
+              setMinimizeToTray(e);
+            }}
+          />
+        }
+      />
+
+      <ConfigOption
+        name="Exit to Tray"
+        description="Exits to the system tray."
+        option={
+          <StyledToggle
+            defaultChecked={exitToTray}
+            checked={exitToTray}
+            onChange={(e: boolean) => {
+              settings.setSync('exitToTray', e);
+              setExitToTray(e);
+            }}
+          />
+        }
+      />
     </ConfigPanel>
   );
 };

--- a/src/components/settings/styled.tsx
+++ b/src/components/settings/styled.tsx
@@ -1,16 +1,26 @@
 import styled from 'styled-components';
 import { Panel } from 'rsuite';
 
+export const ConfigPanelTitle = styled.div`
+  font-size: ${(props) => props.theme.fonts.size.panelTitle};
+  min-width: 500px;
+  max-width: 1200px;
+  margin: 15px auto 15px auto;
+`;
+
 export const ConfigPanel = styled(Panel)`
   color: ${(props) => props.theme.colors.layout.page.color};
-  padding: 20px;
   min-width: 500px;
-  max-width: 800px;
+  max-width: 1200px;
   margin: 15px auto 15px auto;
-  border-radius: ${(props) => props.theme.other.panel.borderRadius};
+  padding: 15px;
+
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 15px;
 
   .rs-panel-heading {
     font-size: ${(props) => props.theme.fonts.size.panelTitle};
+    font-weight: bold;
   }
 `;
 
@@ -27,4 +37,21 @@ export const LoginPanel = styled(Panel)`
   min-width: 300px;
   max-width: 300px;
   margin: 5px auto 5px auto;
+`;
+
+export const ConfigOptionName = styled.div`
+  font-size: 14px;
+  font-weight: bold;
+`;
+
+export const ConfigOptionDescription = styled.div`
+  font-size: 13px;
+`;
+
+export const ConfigOptionSection = styled.div`
+  padding: 15px 0 15px 0;
+`;
+
+export const ConfigOptionInput = styled.div`
+  align-items: center;
 `;

--- a/src/main.dev.js
+++ b/src/main.dev.js
@@ -338,6 +338,43 @@ const createWindow = async () => {
     });
   }
 
+  ipcMain.on('enableGlobalHotkeys', () => {
+    globalShortcut.register('MediaStop', () => {
+      stop();
+    });
+
+    globalShortcut.register('MediaPlayPause', () => {
+      playPause();
+    });
+
+    globalShortcut.register('MediaNextTrack', () => {
+      nextTrack();
+    });
+
+    globalShortcut.register('MediaPreviousTrack', () => {
+      previousTrack();
+    });
+  });
+
+  ipcMain.on('disableGlobalHotkeys', () => {
+    globalShortcut.unregisterAll();
+    electronLocalshortcut.register(mainWindow, 'MediaStop', () => {
+      stop();
+    });
+
+    electronLocalshortcut.register(mainWindow, 'MediaPlayPause', () => {
+      playPause();
+    });
+
+    electronLocalshortcut.register(mainWindow, 'MediaNextTrack', () => {
+      nextTrack();
+    });
+
+    electronLocalshortcut.register(mainWindow, 'MediaPreviousTrack', () => {
+      previousTrack();
+    });
+  });
+
   mainWindow.loadURL(`file://${__dirname}/index.html`);
 
   // @TODO: Use 'ready-to-show' event


### PR DESCRIPTION
- Remove need for app restart when enabling/disabling global media hotkeys
- Add all config options to the top-right action bar config popover
- Update all config panels and added descriptions
- Change single checkboxes to toggles

![image](https://user-images.githubusercontent.com/42182408/146098038-5af6c2d2-c6b1-4ebb-bb9c-3f4559071499.png)
![image](https://user-images.githubusercontent.com/42182408/146098047-6fe931d6-7d14-414b-b2eb-6b60cb9ad3c1.png)
