### PR TITLE
Native titlebar + tray fix

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -134,7 +134,11 @@ const Layout = ({ footer, children, disableSidebar, font }: any) => {
           }
         }}
       >
-        <MainContainer id="container-main" expanded={misc.expandSidebar}>
+        <MainContainer
+          id="container-main"
+          expanded={misc.expandSidebar}
+          $titleBar={misc.titleBar} // transient prop to determine margin
+        >
           <FlexboxGrid
             justify="space-between"
             style={{

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -108,6 +108,7 @@ const Layout = ({ footer, children, disableSidebar, font }: any) => {
         handleSidebarSelect={handleSidebarSelect}
         disableSidebar={disableSidebar}
         font={font}
+        titleBar={misc.titleBar}
         onClick={() => {
           if (misc.contextMenu.show === true) {
             dispatch(

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ const Sidebar = ({
   handleSidebarSelect,
   disableSidebar,
   font,
+  titleBar,
   ...rest
 }: any) => {
   const history = useHistory();
@@ -20,6 +21,7 @@ const Sidebar = ({
       width={expand ? 165 : 56}
       collapsible
       font={font}
+      $titleBar={titleBar} // transient prop to determine position
       onClick={rest.onClick}
     >
       <Sidenav

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -32,7 +32,8 @@ const Titlebar = ({ font }: any) => {
         } ~ ${playQueue[currentEntryList][playQueue.currentIndex]?.artist[0]?.title} `
       : 'Sonixd';
 
-    setTitle(`${playStatus} ${songTitle}`);
+    setTitle(`${playStatus} ${songTitle}`.trim());
+    document.title = `${playStatus} ${songTitle}`.trim();
   }, [playQueue, player.status]);
 
   // if the titlebar is native return no custom titlebar

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -35,6 +35,11 @@ const Titlebar = ({ font }: any) => {
     setTitle(`${playStatus} ${songTitle}`);
   }, [playQueue, player.status]);
 
+  // if the titlebar is native return no custom titlebar
+  if (misc.titleBar === 'native') {
+    return null;
+  }
+
   return (
     <TitleHeader id="titlebar" font={font}>
       <DragRegion id="drag-region">

--- a/src/components/layout/styled.tsx
+++ b/src/components/layout/styled.tsx
@@ -171,7 +171,8 @@ export const FixedSidebar = styled(Sidebar)<{ font: string; $titleBar: string }>
   position: fixed;
   top: ${(props) => (props.$titleBar === 'native' ? '0px' : '32px')};
   z-index: 1;
-  height: calc(100% - 130px);
+  height: ${(props) =>
+    props.$titleBar === 'native' ? 'calc(100% - 98px);' : 'calc(100% - 130px);'};
   font-family: ${(props) => `${props.font?.split(/Light|Medium/)[0]}`};
   font-weight: ${(props) =>
     props.font?.match('Light') ? 300 : props.font?.match('Medium') ? 500 : 400};

--- a/src/components/layout/styled.tsx
+++ b/src/components/layout/styled.tsx
@@ -166,10 +166,10 @@ export const PageContent = styled(Content)<{ padding?: string; $zIndex?: number 
 
 // Sidebar.tsx
 // Add 1 to top if you add window border
-export const FixedSidebar = styled(Sidebar)<{ font: string }>`
+export const FixedSidebar = styled(Sidebar)<{ font: string; $titleBar: string }>`
   background: ${(props) => props.theme.colors.layout.sideBar.background} !important;
   position: fixed;
-  top: 32px;
+  top: ${(props) => (props.$titleBar === 'native' ? '0px' : '32px')};
   z-index: 1;
   height: calc(100% - 130px);
   font-family: ${(props) => `${props.font?.split(/Light|Medium/)[0]}`};

--- a/src/components/layout/styled.tsx
+++ b/src/components/layout/styled.tsx
@@ -271,14 +271,18 @@ export const FlatBackground = styled.div<{ $expanded: boolean; $color: string }>
   pointer-events: none;
 `;
 
-export const BlurredBackgroundWrapper = styled.div<{ expanded: boolean; hasImage: boolean }>`
+export const BlurredBackgroundWrapper = styled.div<{
+  expanded: boolean;
+  hasImage: boolean;
+  $titleBar: string;
+}>`
   clip: rect(0, auto, auto, 0);
   -webkit-clip-path: inset(0 0);
   clip-path: inset(0 0);
   position: absolute;
   left: ${(props) => (props.expanded ? '165px' : '56px')};
   width: ${(props) => (props.expanded ? `calc(100% - 165px)` : 'calc(100% - 56px)')};
-  top: 32px;
+  top: ${(props) => (props.$titleBar === 'native' ? '0px' : '32px')};
   z-index: 1;
   display: block;
   background: ${(props) => (props.hasImage ? '#0b0908' : '#00395A')};

--- a/src/components/layout/styled.tsx
+++ b/src/components/layout/styled.tsx
@@ -23,10 +23,10 @@ const StyledContainer = ({ id, expanded, children, ...props }: ContainerProps) =
   <Container {...props}>{children}</Container>
 );
 
-export const MainContainer = styled(StyledContainer)`
+export const MainContainer = styled(StyledContainer)<{ $titleBar: string }>`
   padding-left: ${(props) => (props.expanded ? '165px' : '56px')};
   height: calc(100% - 32px);
-  margin-top: 32px;
+  margin-top: ${(props) => (props.$titleBar === 'native' ? '0px' : '32px')};
   overflow-y: auto;
 `;
 

--- a/src/components/layout/styled.tsx
+++ b/src/components/layout/styled.tsx
@@ -260,9 +260,9 @@ export const PageHeaderSubtitleDataLine = styled.div<{ $top?: boolean; $overflow
   scroll-behavior: smooth;
 `;
 
-export const FlatBackground = styled.div<{ $expanded: boolean; $color: string }>`
+export const FlatBackground = styled.div<{ $expanded: boolean; $color: string; $titleBar: string }>`
   background: ${(props) => props.$color};
-  top: 32px;
+  top: ${(props) => (props.$titleBar === 'native' ? '0px' : '32px')};
   left: ${(props) => (props.$expanded ? '165px' : '56px')};
   height: 200px;
   position: absolute;
@@ -307,13 +307,17 @@ export const BlurredBackground = styled.img<{ expanded: boolean }>`
   display: block;
 `;
 
-export const GradientBackground = styled.div<{ $expanded: boolean; $color: string }>`
+export const GradientBackground = styled.div<{
+  $expanded: boolean;
+  $color: string;
+  $titleBar: string;
+}>`
   background: ${(props) =>
     `linear-gradient(0deg, transparent 10%, ${props.$color.replace(
       ',1)',
       `${props.theme.type === 'dark' ? ',0.2' : ',0.5'})`
     )} 100%)`};
-  top: 32px;
+  top: ${(props) => (props.$titleBar === 'native' ? '0px' : '32px')};
   left: ${(props) => (props.$expanded ? '165px' : '56px')};
   height: calc(100% - 130px);
   position: absolute;

--- a/src/components/library/AlbumView.tsx
+++ b/src/components/library/AlbumView.tsx
@@ -289,6 +289,7 @@ const AlbumView = ({ ...rest }: any) => {
         <BlurredBackgroundWrapper
           hasImage={!data?.image.match('placeholder')}
           expanded={misc.expandSidebar}
+          $titleBar={misc.titleBar} // transient prop to determine margin
         >
           <BlurredBackground
             // We have to use an inline style here due to the context menu forcing a component rerender

--- a/src/components/library/ArtistView.tsx
+++ b/src/components/library/ArtistView.tsx
@@ -343,7 +343,11 @@ const ArtistView = ({ ...rest }: any) => {
   return (
     <>
       {!rest.isModal && (
-        <GradientBackground $expanded={misc.expandSidebar} $color={imageAverageColor.color} />
+        <GradientBackground
+          $expanded={misc.expandSidebar}
+          $color={imageAverageColor.color}
+          $titleBar={misc.titleBar}
+        />
       )}
       <GenericPage
         contentZIndex={1}

--- a/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
+++ b/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
@@ -365,6 +365,10 @@ export const ThemeConfigPanel = ({ bordered }: any) => {
                   label: 'Windows',
                   value: 'windows',
                 },
+                {
+                  label: 'Native',
+                  value: 'native',
+                },
               ]}
               cleanable={false}
               defaultValue={String(settings.getSync('titleBarStyle'))}

--- a/src/main.dev.js
+++ b/src/main.dev.js
@@ -301,7 +301,7 @@ const createWindow = async () => {
     autoHideMenuBar: true,
     minWidth: 768,
     minHeight: 600,
-    frame: false,
+    frame: settings.getSync('titleBarStyle') === 'native',
   });
 
   if (settings.getSync('globalMediaHotkeys')) {

--- a/src/main.dev.js
+++ b/src/main.dev.js
@@ -511,7 +511,7 @@ const createTray = () => {
     return;
   }
 
-  tray = new Tray(getAssetPath('icon.ico'));
+  tray = isLinux ? new Tray(getAssetPath('icon.png')) : new Tray(getAssetPath('icon.ico'));
   const contextMenu = Menu.buildFromTemplate([
     {
       label: 'Open main window',

--- a/src/main.dev.js
+++ b/src/main.dev.js
@@ -478,7 +478,7 @@ const createWindow = async () => {
     });
   }
 
-  mainWindow.on('maximize', () => {
+  mainWindow.once('maximize', () => {
     settings.setSync('windowMaximize', true);
   });
 
@@ -583,6 +583,15 @@ app.on('activate', () => {
 });
 
 ipcMain.on('reload', () => {
-  app.quit();
-  createWindow();
+  if (process.env.APPIMAGE) {
+    app.exit();
+    app.relaunch({
+      execPath: process.env.APPIMAGE,
+      args: process.argv.slice(1).concat(['--appimage-extract-and-run']),
+    });
+    app.exit(0);
+  } else {
+    app.relaunch();
+    app.exit();
+  }
 });

--- a/src/main.dev.js
+++ b/src/main.dev.js
@@ -581,3 +581,8 @@ app.on('activate', () => {
   // dock icon is clicked and there are no other windows open.
   if (mainWindow === null) createWindow();
 });
+
+ipcMain.on('reload', () => {
+  app.quit();
+  createWindow();
+});

--- a/src/redux/miscSlice.ts
+++ b/src/redux/miscSlice.ts
@@ -51,7 +51,7 @@ export interface General {
   highlightOnRowHover: boolean;
   imageCachePath: string;
   songCachePath: string;
-  titleBar: 'windows' | 'mac' | string;
+  titleBar: 'windows' | 'mac' | 'native' | string;
   searchQuery: string;
 }
 


### PR DESCRIPTION
I implemented the reload function like you said, which then worked 🙂
I also added the whisper to the titlebar style select, which tells the user to restart.

Another thing I put into this branch, which does not really belong into this branch, is a fix for the tray on linux.
The tray icon won't be created on Linux because the ico file isn't loaded for some reason.
The png icon works though, which is then used when on Linux.