### PR TITLE
Add OBS (tuna) integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "css-loader": "^5.0.1",
     "css-minimizer-webpack-plugin": "^1.1.5",
     "detect-port": "^1.3.0",
-    "electron": "13.3.0",
+    "electron": "13.6.3",
     "electron-builder": "^22.10.5",
     "electron-devtools-installer": "git+https://github.com/MarshallOfSound/electron-devtools-installer.git",
     "electron-notarize": "^1.0.0",

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -383,6 +383,15 @@ const configState: ConfigPage = {
       alignment: 'flex-start',
     },
   },
+  external: {
+    obs: {
+      enabled: false,
+      url: '',
+      path: '',
+      pollingInterval: 2000,
+      type: 'local',
+    },
+  },
 };
 
 const favoriteState: FavoritePage = {

--- a/src/components/debug/DebugWindow.tsx
+++ b/src/components/debug/DebugWindow.tsx
@@ -129,7 +129,6 @@ const DebugWindow = ({ ...rest }) => {
               {player.status}
             </span>
           </li>
-          <li>currentSeek: {player.currentSeek.toFixed(2)}</li>
           <li>volume (global): {playQueue.volume.toFixed(2)}</li>
           <li>volumeFade: {playQueue.volumeFade ? 'true' : 'false'}</li>
           <li>shuffle: {playQueue.shuffle ? 'true' : 'false'}</li>

--- a/src/components/player/PlayerBar.tsx
+++ b/src/components/player/PlayerBar.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import axios from 'axios';
+import fs from 'fs';
+import path from 'path';
 import { useQueryClient } from 'react-query';
 import settings from 'electron-settings';
 import { FlexboxGrid, Grid, Row, Col, Whisper } from 'rsuite';
@@ -32,10 +34,16 @@ import CustomTooltip from '../shared/CustomTooltip';
 import placeholderImg from '../../img/placeholder.png';
 import DebugWindow from '../debug/DebugWindow';
 import { CoverArtWrapper } from '../layout/styled';
-import { getCurrentEntryList, isCached, writeOBSFiles } from '../../shared/utils';
+import {
+  decodeBase64Image,
+  getCurrentEntryList,
+  isCached,
+  writeOBSFiles,
+} from '../../shared/utils';
 import { StyledPopover } from '../shared/styled';
 import { apiController } from '../../api/controller';
 import { Artist, Server } from '../../types';
+import logo from '../../../assets/icon.png';
 
 const PlayerBar = () => {
   const queryClient = useQueryClient();
@@ -122,6 +130,19 @@ const PlayerBar = () => {
             status: player.status === 'PLAYING' ? 'playing' : 'stopped',
             title: playQueue.current?.title,
           });
+
+          if (playQueue.current?.image.match('placeholder')) {
+            const imgBuffer = decodeBase64Image(logo);
+            fs.writeFile(
+              path.join(config.external.obs.path, 'cover.jpg'),
+              imgBuffer.data,
+              (err) => {
+                if (err) {
+                  console.log(err);
+                }
+              }
+            );
+          }
         }
       }, config.external.obs.pollingInterval);
 

--- a/src/components/settings/Config.tsx
+++ b/src/components/settings/Config.tsx
@@ -18,6 +18,7 @@ import ServerConfig from './ConfigPanels/ServerConfig';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { setActive } from '../../redux/configSlice';
 import { apiController } from '../../api/controller';
+import ExternalConfig from './ConfigPanels/ExternalConfig';
 
 const GITHUB_RELEASE_URL = 'https://api.github.com/repos/jeffvli/sonixd/releases?per_page=3';
 
@@ -233,6 +234,7 @@ const Config = () => {
           <ServerConfig />
           <CacheConfig />
           {!showWindowConfig && <WindowConfig />}
+          <ExternalConfig />
           <AdvancedConfig />
         </>
       )}

--- a/src/components/settings/ConfigPanels/ExternalConfig.tsx
+++ b/src/components/settings/ConfigPanels/ExternalConfig.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import settings from 'electron-settings';
+import { Icon, RadioGroup } from 'rsuite';
+import { ConfigOptionDescription, ConfigPanel } from '../styled';
+import {
+  StyledInput,
+  StyledInputGroup,
+  StyledInputGroupButton,
+  StyledInputNumber,
+  StyledRadio,
+  StyledToggle,
+} from '../../shared/styled';
+import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
+import { setOBS } from '../../../redux/configSlice';
+import ConfigOption from '../ConfigOption';
+
+const { dialog } = require('electron').remote;
+
+const ExternalConfig = () => {
+  const dispatch = useAppDispatch();
+  const config = useAppSelector((state) => state.config);
+
+  return (
+    <ConfigPanel header="External">
+      <ConfigOptionDescription>
+        Config for integration with external programs.
+      </ConfigOptionDescription>
+      <ConfigPanel header="OBS (Open Broadcaster Software)" collapsible $noBackground>
+        <ConfigOption
+          name={
+            <>
+              Scrobbling
+              <RadioGroup
+                inline
+                defaultValue={config.external.obs.type}
+                value={config.external.obs.type}
+                onChange={(e: string) => {
+                  settings.setSync('obs.type', e);
+                  dispatch(setOBS({ ...config.external.obs, type: e }));
+                }}
+              >
+                <StyledRadio value="local">Local</StyledRadio>
+                <StyledRadio value="web">Web</StyledRadio>
+              </RadioGroup>
+            </>
+          }
+          description="If local, scrobbles the currently playing song to local .txt files. If web, scrobbles the currently playing song to Tuna plugin's webserver."
+          option={
+            <>
+              <StyledToggle
+                defaultChecked={config.external.obs.enabled}
+                checked={config.external.obs.enabled}
+                onChange={(e: boolean) => {
+                  settings.setSync('obs.enabled', e);
+                  dispatch(setOBS({ ...config.external.obs, enabled: e }));
+                }}
+              />
+            </>
+          }
+        />
+        <ConfigOption
+          name="Polling Interval"
+          description="The number in milliseconds (ms) between each poll when metadata is sent."
+          option={
+            <StyledInputNumber
+              defaultValue={config.external.obs.pollingInterval}
+              value={config.external.obs.pollingInterval}
+              step={1}
+              min={100}
+              max={25000}
+              width={125}
+              onChange={(e: number) => {
+                settings.setSync('obs.pollingInterval', e);
+                dispatch(setOBS({ ...config.external.obs, pollingInterval: e }));
+              }}
+            />
+          }
+        />
+
+        {config.external.obs.type === 'web' ? (
+          <ConfigOption
+            name="Tuna Webserver Url"
+            description="The full URL to the Tuna webserver."
+            option={
+              <StyledInput
+                width={200}
+                placeholder="http://localhost:1608"
+                value={config.external.obs.url}
+                onChange={(e: string) => {
+                  settings.setSync('obs.url', e);
+                  dispatch(setOBS({ ...config.external.obs, url: e }));
+                }}
+              />
+            }
+          />
+        ) : (
+          <ConfigOption
+            name="File Path"
+            description="The full path to the directory where song metadata will be created."
+            option={
+              <StyledInputGroup>
+                <StyledInput disabled width={200} value={config.external.obs.path} />
+                <StyledInputGroupButton
+                  onClick={() => {
+                    const path = dialog.showOpenDialogSync({
+                      properties: ['openFile', 'openDirectory'],
+                    });
+
+                    if (path) {
+                      settings.setSync('obs.path', path[0]);
+                      dispatch(setOBS({ ...config.external.obs, path: path[0] }));
+                    }
+                  }}
+                >
+                  <Icon icon="folder-open" />
+                </StyledInputGroupButton>
+              </StyledInputGroup>
+            }
+          />
+        )}
+      </ConfigPanel>
+    </ConfigPanel>
+  );
+};
+
+export default ExternalConfig;

--- a/src/components/settings/ConfigPanels/ExternalConfig.tsx
+++ b/src/components/settings/ConfigPanels/ExternalConfig.tsx
@@ -14,7 +14,7 @@ import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
 import { setOBS } from '../../../redux/configSlice';
 import ConfigOption from '../ConfigOption';
 
-const { dialog } = require('electron').remote;
+const dialog: any = process.env.NODE_ENV === 'test' ? '' : require('electron').remote.dialog;
 
 const ExternalConfig = () => {
   const dispatch = useAppDispatch();

--- a/src/components/settings/styled.tsx
+++ b/src/components/settings/styled.tsx
@@ -8,19 +8,23 @@ export const ConfigPanelTitle = styled.div`
   margin: 15px auto 15px auto;
 `;
 
-export const ConfigPanel = styled(Panel)`
+export const ConfigPanel = styled(Panel)<{ $noBackground: boolean }>`
   color: ${(props) => props.theme.colors.layout.page.color};
   min-width: 500px;
   max-width: 1200px;
-  margin: 15px auto 15px auto;
+  margin: ${(props) => (props.collapsible ? 'none' : '15px auto 15px auto')};
   padding: 15px;
 
-  background: rgba(0, 0, 0, 0.1);
+  background: ${(props) => (props.$noBackground ? 'none' : 'rgba(0, 0, 0, 0.1)')};
   border-radius: 15px;
 
   .rs-panel-heading {
     font-size: ${(props) => props.theme.fonts.size.panelTitle};
     font-weight: bold;
+  }
+
+  .rs-panel-collapsible > .rs-panel-heading::before {
+    top: 0px !important;
   }
 `;
 

--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -2,6 +2,26 @@ import settings from 'electron-settings';
 import path from 'path';
 
 const setDefaultSettings = (force: boolean) => {
+  if (force || !settings.hasSync('obs.enabled')) {
+    settings.setSync('obs.enabled', false);
+  }
+
+  if (force || !settings.hasSync('obs.url')) {
+    settings.setSync('obs.url', '');
+  }
+
+  if (force || !settings.hasSync('obs.type')) {
+    settings.setSync('obs.type', 'local');
+  }
+
+  if (force || !settings.hasSync('obs.path')) {
+    settings.setSync('obs.path', '');
+  }
+
+  if (force || !settings.hasSync('obs.pollingInterval')) {
+    settings.setSync('obs.pollingInterval', 2000);
+  }
+
   if (force || !settings.hasSync('autoUpdate')) {
     settings.setSync('autoUpdate', true);
   }

--- a/src/redux/configSlice.ts
+++ b/src/redux/configSlice.ts
@@ -43,6 +43,15 @@ export interface ConfigPage {
       alignment: string | 'flex-start' | 'center';
     };
   };
+  external: {
+    obs: {
+      enabled: boolean;
+      url: string;
+      path: string;
+      pollingInterval: number;
+      type: 'web' | 'local';
+    };
+  };
   serverType: Server;
 }
 
@@ -128,6 +137,15 @@ const initialState: ConfigPage = {
       cardSize: Number(parsedSettings.gridCardSize),
       gapSize: Number(parsedSettings.gridGapSize),
       alignment: String(parsedSettings.gridAlignment),
+    },
+  },
+  external: {
+    obs: {
+      enabled: parsedSettings.obs.enabled || false,
+      url: parsedSettings.obs.url || '',
+      path: parsedSettings.obs.path || '',
+      pollingInterval: parsedSettings.obs.pollingInterval || 1000,
+      type: parsedSettings.obs.type || 'local',
     },
   },
   serverType: parsedSettings.serverType,
@@ -233,6 +251,10 @@ const configSlice = createSlice({
         action.payload.moveBeforeId
       );
     },
+
+    setOBS: (state, action: PayloadAction<any>) => {
+      state.external.obs = action.payload;
+    },
   },
 });
 
@@ -251,5 +273,6 @@ export const {
   setGridGapSize,
   setGridAlignment,
   moveToIndex,
+  setOBS,
 } = configSlice.actions;
 export default configSlice.reducer;

--- a/src/shared/mockSettings.ts
+++ b/src/shared/mockSettings.ts
@@ -317,6 +317,13 @@ export const mockSettings = {
   windowMaximize: false,
   highlightOnRowHover: false,
   titleBarStyle: 'windows',
+  obs: {
+    enabled: true,
+    url: '',
+    type: 'local',
+    path: 'C:\\Temp',
+    pollingInterval: '2000',
+  },
   themesDefault: [
     {
       label: 'Default Dark',

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -5,6 +5,9 @@ import moment from 'moment';
 import arrayMove from 'array-move';
 import settings from 'electron-settings';
 import { mockSettings } from './mockSettings';
+import logo from '../../assets/icon.png';
+
+const download = require('image-downloader');
 
 export const isCached = (filePath: string) => {
   return fs.existsSync(filePath);
@@ -505,4 +508,80 @@ export const getAlbumSize = (songs: any[]) => {
       return o.size;
     })
   );
+};
+
+export const base64Encode = (file: any) => {
+  return fs.readFileSync(file, { encoding: 'base64' });
+};
+
+export const decodeBase64Image = (dataString: any) => {
+  const matches = dataString.match(/^data:([A-Za-z-+/]+);base64,(.+)$/);
+  const response: any = {};
+
+  if (matches.length !== 3) {
+    return new Error('Invalid input string');
+  }
+
+  // eslint-disable-next-line prefer-destructuring
+  response.type = matches[1];
+  response.data = Buffer.from(matches[2], 'base64');
+
+  return response;
+};
+
+export const writeOBSFiles = (filePath: string, data: any) => {
+  fs.writeFile(path.join(filePath, 'album.txt'), data.album || '', (err) => {
+    if (err) {
+      console.log(err);
+    }
+  });
+  fs.writeFile(path.join(filePath, 'artists.txt'), (data.artists || []).join(', '), (err) => {
+    if (err) {
+      console.log(err);
+    }
+  });
+  fs.writeFile(
+    path.join(filePath, 'cover.txt'),
+    data.cover_url?.replaceAll('150', '250') || '',
+    (err) => {
+      if (err) {
+        console.log(err);
+      }
+    }
+  );
+  fs.writeFile(path.join(filePath, 'duration.txt'), String(data.duration) || '0', (err) => {
+    if (err) {
+      console.log(err);
+    }
+  });
+  fs.writeFile(path.join(filePath, 'progress.txt'), String(data.progress) || '0', (err) => {
+    if (err) {
+      console.log(err);
+    }
+  });
+  fs.writeFile(path.join(filePath, 'status.txt'), data.status || '', (err) => {
+    if (err) {
+      console.log(err);
+    }
+  });
+  fs.writeFile(path.join(filePath, 'title.txt'), data.title || '', (err) => {
+    if (err) {
+      console.log(err);
+    }
+  });
+
+  if (data.cover_url) {
+    download.image({
+      url: data.cover_url.replaceAll('150', '250'),
+      dest: path.join(filePath, 'cover.jpg'),
+    });
+  } else {
+    const coverPath = path.join(filePath, 'cover.jpg');
+    const imgBuffer = decodeBase64Image(logo);
+    fs.writeFile(coverPath, imgBuffer.data, (err) => {
+      if (err) {
+        console.log(err);
+      }
+    });
+  }
 };

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -5,7 +5,6 @@ import moment from 'moment';
 import arrayMove from 'array-move';
 import settings from 'electron-settings';
 import { mockSettings } from './mockSettings';
-import logo from '../../assets/icon.png';
 
 const download = require('image-downloader');
 
@@ -540,15 +539,6 @@ export const writeOBSFiles = (filePath: string, data: any) => {
       console.log(err);
     }
   });
-  fs.writeFile(
-    path.join(filePath, 'cover.txt'),
-    data.cover_url?.replaceAll('150', '250') || '',
-    (err) => {
-      if (err) {
-        console.log(err);
-      }
-    }
-  );
   fs.writeFile(path.join(filePath, 'duration.txt'), String(data.duration) || '0', (err) => {
     if (err) {
       console.log(err);
@@ -574,14 +564,6 @@ export const writeOBSFiles = (filePath: string, data: any) => {
     download.image({
       url: data.cover_url.replaceAll('150', '250'),
       dest: path.join(filePath, 'cover.jpg'),
-    });
-  } else {
-    const coverPath = path.join(filePath, 'cover.jpg');
-    const imgBuffer = decodeBase64Image(logo);
-    fs.writeFile(coverPath, imgBuffer.data, (err) => {
-      if (err) {
-        console.log(err);
-      }
     });
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4925,10 +4925,10 @@ electron-updater@^4.3.4:
     lodash.isequal "^4.5.0"
     semver "^7.3.2"
 
-electron@13.3.0:
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-13.3.0.tgz#5f4f245723dd50fcd2c3d386a1d66fe748af404f"
-  integrity sha512-d/BvOLDjI4i7yf9tqCuLL2fFGA2TrM/D9PyRpua+rJolG0qrwp/FohP02L0m+44kmPpofIo4l3NPwLmzyKKimA==
+electron@13.6.3:
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.6.3.tgz#c0217178807d3e0b2175c49dbe33ea8dac447e73"
+  integrity sha512-kevgR6/RuEhchJQbgCKhHle9HvJhi2dOJlicFZJqbbqa9BVpZARqqFDlwTSatYxmUPUJwu09FvyMwJG2DMQIng==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
Closes #136

Adds external scrobbling for OBS (Tuna plugin) support
Bumps electron version from 13.3.0 -> 13.6.3 (attempt to resolve SSL cert errors when downloading images)

## Local scrobbling
![image](https://user-images.githubusercontent.com/42182408/147084910-c030f25a-208d-464b-944e-708af12beff4.png)
Creates the following files to a user-specified location:
 - album.txt
 - artists.txt
 - duration.txt
 - progress.txt
 - status.txt
 - title.txt
 - cover.jpg 

## Web scrobbling
![image](https://user-images.githubusercontent.com/42182408/147084937-72d38213-43f1-435a-b1a8-c6af2bfd4ef7.png)
Sends a POST request to the Tuna webserver with the current song details (similar to the Tuna browser userscript.

