### PR TITLE
Add transcode setting to Jellyfin

### DIFF
--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -30,6 +30,10 @@ const setDefaultSettings = (force: boolean) => {
     settings.setSync('obs.pollingInterval', 2000);
   }
 
+  if (force || !settings.hasSync('transcode')) {
+    settings.setSync('transcode', false);
+  }
+
   if (force || !settings.hasSync('autoUpdate')) {
     settings.setSync('autoUpdate', true);
   }

--- a/src/shared/mockSettings.ts
+++ b/src/shared/mockSettings.ts
@@ -20,6 +20,7 @@ export const mockSettings = {
   fadeDuration: 9,
   fadeType: 'equalPower',
   scrobble: false,
+  transcode: false,
   playbackFilters: [
     {
       filter: '(（|\\(|\\[|~|-)[Ii]nst(rumental)?(\\)|\\]|~|-|）)',


### PR DESCRIPTION
Add a toggle that allows user to allow transcoding. This is a static switch for on/off that requires an app restart.
Added due to Jellyfin API currently forcing transcoding off which then fails to play certain files for users with unsupported filetypes.

Closes #158 