### PR TITLE
Add ability to choose a specific start page

### DIFF
--- a/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
+++ b/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
@@ -275,6 +275,7 @@ export const ThemeConfigPanel = ({ bordered }: any) => {
   const themePickerContainerRef = useRef(null);
   const fontPickerContainerRef = useRef(null);
   const titleBarPickerContainerRef = useRef(null);
+  const startPagePickerContainerRef = useRef(null);
   const titleBarRestartWhisper = React.createRef<WhisperInstance>();
   const [themeList, setThemeList] = useState(
     _.concat(settings.getSync('themes'), settings.getSync('themesDefault'))
@@ -424,6 +425,54 @@ export const ThemeConfigPanel = ({ bordered }: any) => {
               setDynamicBackgroundChk(e);
             }}
           />
+        }
+      />
+
+      <ConfigOption
+        name="Start page"
+        description="Page Sonixd will display on start."
+        option={
+          <StyledInputPickerContainer ref={startPagePickerContainerRef}>
+            <StyledInputPicker
+              container={() => startPagePickerContainerRef.current}
+              data={[
+                {
+                  label: 'Dashboard',
+                  value: '/',
+                },
+                {
+                  label: 'Playlists',
+                  value: '/playlist',
+                },
+                {
+                  label: 'Favorites',
+                  value: '/starred',
+                },
+                {
+                  label: 'Albums',
+                  value: '/library/album',
+                },
+                {
+                  label: 'Artists',
+                  value: '/library/artist',
+                },
+                {
+                  label: 'Genres',
+                  value: '/library/genre',
+                },
+                {
+                  label: 'Folders',
+                  value: '/library/folder',
+                },
+              ]}
+              cleanable={false}
+              defaultValue={String(settings.getSync('startPage'))}
+              width={200}
+              onChange={(e: string) => {
+                settings.setSync('startPage', e);
+              }}
+            />
+          </StyledInputPickerContainer>
         }
       />
     </ConfigPanel>

--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -86,6 +86,10 @@ const setDefaultSettings = (force: boolean) => {
     settings.setSync('titleBarStyle', 'windows');
   }
 
+  if (force || !settings.hasSync('startPage')) {
+    settings.setSync('startPage', '/');
+  }
+
   if (force || !settings.hasSync('scrobble')) {
     settings.setSync('scrobble', false);
   }

--- a/src/main.dev.js
+++ b/src/main.dev.js
@@ -460,7 +460,7 @@ const createWindow = async () => {
     });
   });
 
-  mainWindow.loadURL(`file://${__dirname}/index.html`);
+  mainWindow.loadURL(`file://${__dirname}/index.html#${settings.getSync('startPage')}`);
 
   // @TODO: Use 'ready-to-show' event
   // https://github.com/electron/electron/blob/master/docs/api/browser-window.md#using-ready-to-show-event

--- a/src/shared/mockSettings.ts
+++ b/src/shared/mockSettings.ts
@@ -318,6 +318,7 @@ export const mockSettings = {
   windowMaximize: false,
   highlightOnRowHover: false,
   titleBarStyle: 'windows',
+  startPage: '/',
   discord: {
     enabled: true,
     applicationId: '',


### PR DESCRIPTION
This will add a dropdown menu to the settings where one can choose on which page sonixd will start.

![2022-01-07_09 09 31-8e614f](https://user-images.githubusercontent.com/6004892/148574044-33138b77-2ca2-473f-95ff-02032f840059.png)

