### PR TITLE
Add ability to choose default album sorting

### DIFF
--- a/src/components/library/AlbumList.tsx
+++ b/src/components/library/AlbumList.tsx
@@ -34,7 +34,7 @@ import useAdvancedFilter from '../../hooks/useAdvancedFilter';
 import ColumnSort from '../shared/ColumnSort';
 import useColumnSort from '../../hooks/useColumnSort';
 
-const ALBUM_SORT_TYPES = [
+export const ALBUM_SORT_TYPES = [
   { label: 'A-Z (Name)', value: 'alphabeticalByName', role: 'Default' },
   { label: 'A-Z (Artist)', value: 'alphabeticalByArtist', role: 'Default' },
   { label: 'Most Played', value: 'frequent', role: 'Default' },

--- a/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
+++ b/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
@@ -479,7 +479,7 @@ export const ThemeConfigPanel = ({ bordered }: any) => {
       />
 
       <ConfigOption
-        name="Default album sorting"
+        name="Default Album Sort"
         description="Choose with which sorting the album page will open."
         option={
           <StyledInputPickerContainer ref={albumSortDefaultPickerContainerRef}>

--- a/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
+++ b/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../shared/styled';
 import ListViewConfig from './ListViewConfig';
 import { Fonts } from '../Fonts';
+import { ALBUM_SORT_TYPES } from '../../library/AlbumList';
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
 import { setTheme, setFont, setDynamicBackground, setMiscSetting } from '../../../redux/miscSlice';
 import {
@@ -276,6 +277,7 @@ export const ThemeConfigPanel = ({ bordered }: any) => {
   const fontPickerContainerRef = useRef(null);
   const titleBarPickerContainerRef = useRef(null);
   const startPagePickerContainerRef = useRef(null);
+  const albumSortDefaultPickerContainerRef = useRef(null);
   const titleBarRestartWhisper = React.createRef<WhisperInstance>();
   const [themeList, setThemeList] = useState(
     _.concat(settings.getSync('themes'), settings.getSync('themesDefault'))
@@ -470,6 +472,25 @@ export const ThemeConfigPanel = ({ bordered }: any) => {
               width={200}
               onChange={(e: string) => {
                 settings.setSync('startPage', e);
+              }}
+            />
+          </StyledInputPickerContainer>
+        }
+      />
+
+      <ConfigOption
+        name="Default album sorting"
+        description="Choose with which sorting the album page will open."
+        option={
+          <StyledInputPickerContainer ref={albumSortDefaultPickerContainerRef}>
+            <StyledInputPicker
+              container={() => albumSortDefaultPickerContainerRef.current}
+              data={ALBUM_SORT_TYPES}
+              cleanable={false}
+              defaultValue={String(settings.getSync('albumSortDefault'))}
+              width={200}
+              onChange={(e: string) => {
+                settings.setSync('albumSortDefault', e);
               }}
             />
           </StyledInputPickerContainer>

--- a/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
+++ b/src/components/settings/ConfigPanels/LookAndFeelConfig.tsx
@@ -268,6 +268,7 @@ export const GridViewConfigPanel = ({ bordered }: any) => {
 
 export const ThemeConfigPanel = ({ bordered }: any) => {
   const dispatch = useAppDispatch();
+  const config = useAppSelector((state) => state.config);
   const [dynamicBackgroundChk, setDynamicBackgroundChk] = useState(
     Boolean(settings.getSync('dynamicBackground'))
   );
@@ -480,12 +481,15 @@ export const ThemeConfigPanel = ({ bordered }: any) => {
 
       <ConfigOption
         name="Default Album Sort"
-        description="Choose with which sorting the album page will open."
+        description="The default album page sort selection on application startup."
         option={
           <StyledInputPickerContainer ref={albumSortDefaultPickerContainerRef}>
             <StyledInputPicker
               container={() => albumSortDefaultPickerContainerRef.current}
               data={ALBUM_SORT_TYPES}
+              disabledItemValues={
+                config.serverType === Server.Jellyfin ? ['frequent', 'recent'] : []
+              }
               cleanable={false}
               defaultValue={String(settings.getSync('albumSortDefault'))}
               width={200}

--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -190,6 +190,10 @@ const setDefaultSettings = (force: boolean) => {
     settings.setSync('albumViewType', 'list');
   }
 
+  if (force || !settings.hasSync('albumSortDefault')) {
+    settings.setSync('albumSortDefault', 'random');
+  }
+
   if (force || !settings.hasSync('artistViewType')) {
     settings.setSync('artistViewType', 'list');
   }

--- a/src/redux/albumSlice.ts
+++ b/src/redux/albumSlice.ts
@@ -35,7 +35,11 @@ export interface AdvancedFilters {
 
 const initialState: AlbumPage = {
   active: {
-    filter: String(parsedSettings.albumSortDefault),
+    filter:
+      parsedSettings.serverType === 'jellyfin' &&
+      ['frequent', 'recent'].includes(String(parsedSettings.albumSortDefault))
+        ? 'random'
+        : String(parsedSettings.albumSortDefault),
   },
   advancedFilters: {
     enabled: false,

--- a/src/redux/albumSlice.ts
+++ b/src/redux/albumSlice.ts
@@ -1,5 +1,9 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import settings from 'electron-settings';
+import { mockSettings } from '../shared/mockSettings';
 import { Sort } from '../types';
+
+const parsedSettings = process.env.NODE_ENV === 'test' ? mockSettings : settings.getSync();
 
 export interface AlbumPage {
   active: {
@@ -31,7 +35,7 @@ export interface AdvancedFilters {
 
 const initialState: AlbumPage = {
   active: {
-    filter: 'random',
+    filter: String(parsedSettings.albumSortDefault),
   },
   advancedFilters: {
     enabled: false,

--- a/src/shared/mockSettings.ts
+++ b/src/shared/mockSettings.ts
@@ -41,6 +41,7 @@ export const mockSettings = {
   gridAlignment: 'flex-start',
   playlistViewType: 'grid',
   albumViewType: 'grid',
+  albumSortDefault: 'random',
   musicListFontSize: 13,
   musicListRowHeight: 50,
   musicListColumns: [


### PR DESCRIPTION
This will add a dropdown menu to the settings where one can choose with which album sorting sonixd will start.

Implementation of #169

![2022-01-08_12 44 44-3afef8](https://user-images.githubusercontent.com/6004892/148643217-bae7566c-e673-43aa-8788-fb31db4a4b23.png)