### PR TITLE
Allow custom installation directory in windows installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
       "img/"
     ],
     "afterSign": ".erb/scripts/Notarize.js",
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true
+    },
     "mac": {
       "target": [
         "dmg"


### PR DESCRIPTION
I guess this will solve #175. (There's no description beside the title.)

The installer still finds old installations and will update them.