### PR TITLE
Remove custom image caching

### DIFF
--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -3,7 +3,6 @@ import { Icon } from 'rsuite';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
-import cacheImage from '../shared/cacheImage';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import {
   appendPlayQueue,
@@ -11,7 +10,7 @@ import {
   fixPlayer2Index,
   setPlayQueue,
 } from '../../redux/playQueueSlice';
-import { filterPlayQueue, getPlayedSongsNotification, isCached } from '../../shared/utils';
+import { filterPlayQueue, getPlayedSongsNotification } from '../../shared/utils';
 
 import {
   CardPanel,
@@ -47,8 +46,6 @@ const Card = ({
   lazyLoad,
   playClick,
   size,
-  cacheImages,
-  cachePath,
   handleFavorite,
   notVisibleByDefault,
   noInfoPanel,
@@ -268,23 +265,10 @@ const Card = ({
               <CardImgWrapper size={size} onClick={handleClick}>
                 {lazyLoad ? (
                   <LazyCardImg
-                    src={
-                      isCached(`${cachePath}${rest.details.cacheType}_${rest.details.id}.jpg`)
-                        ? `${cachePath}${rest.details.cacheType}_${rest.details.id}.jpg`
-                        : rest.coverArt
-                    }
+                    src={rest.coverArt}
                     alt="img"
-                    effect="opacity"
                     cardsize={size}
                     visibleByDefault={!notVisibleByDefault}
-                    afterLoad={() => {
-                      if (cacheImages) {
-                        cacheImage(
-                          `${rest.details.cacheType}_${rest.details.id}.jpg`,
-                          rest.coverArt.replaceAll(/=150/gi, '=350')
-                        );
-                      }
-                    }}
                   />
                 ) : (
                   <CardImg src={rest.coverArt} alt="img" onClick={handleClick} cardsize={size} />

--- a/src/components/layout/GenericPage.tsx
+++ b/src/components/layout/GenericPage.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { Divider } from 'rsuite';
 import { useAppSelector } from '../../redux/hooks';
 import { PageContainer, PageHeader, PageContent } from './styled';
-import { isCached } from '../../shared/utils';
 
 const GenericPage = ({ header, children, hideDivider, ...rest }: any) => {
   const playQueue = useAppSelector((state) => state.playQueue);
@@ -11,23 +10,16 @@ const GenericPage = ({ header, children, hideDivider, ...rest }: any) => {
 
   useEffect(() => {
     if (misc.dynamicBackground) {
-      const cachedImagePath = `${misc.imageCachePath}album_${playQueue.current?.albumId}.jpg`;
       const serverImagePath = playQueue.current?.image.replace(/size=\d+/, 'size=500');
-      const cssBackgroundImagePath = `${misc.imageCachePath}album_${playQueue.current?.albumId}.jpg`.replaceAll(
-        '\\',
-        '/'
-      );
+      const preloadImage = new Image();
+      preloadImage.src = serverImagePath;
+      const imagePath = serverImagePath;
 
-      if (!isCached(cachedImagePath)) {
-        const preloadImage = new Image();
-        preloadImage.src = serverImagePath;
+      if (imagePath) {
+        setBackgroundImage(imagePath);
       }
-
-      const imagePath = isCached(cachedImagePath) ? cssBackgroundImagePath : serverImagePath;
-
-      setBackgroundImage(imagePath);
     }
-  }, [misc.imageCachePath, misc.dynamicBackground, playQueue]);
+  }, [misc.dynamicBackground, playQueue]);
 
   return (
     <PageContainer

--- a/src/components/layout/GenericPageHeader.tsx
+++ b/src/components/layout/GenericPageHeader.tsx
@@ -17,7 +17,6 @@ import {
   PageHeaderTitle,
   PageHeaderWrapper,
 } from './styled';
-import cacheImage from '../shared/cacheImage';
 import CustomTooltip from '../shared/CustomTooltip';
 
 const GenericPageHeader = ({
@@ -35,7 +34,6 @@ const GenericPageHeader = ({
   handleListClick,
   handleGridClick,
   viewTypeSetting,
-  cacheImages,
   showTitleTooltip,
   isDark,
 }: any) => {
@@ -54,14 +52,6 @@ const GenericPageHeader = ({
               alt="header-img"
               height={imageHeight || '195px'}
               visibleByDefault
-              afterLoad={() => {
-                if (cacheImages.enabled) {
-                  cacheImage(
-                    `${cacheImages.cacheType}_${cacheImages.id}.jpg`,
-                    image.replaceAll(/=150/gi, '=350')
-                  );
-                }
-              }}
             />
           )}
         </CoverArtWrapper>

--- a/src/components/layout/styled.tsx
+++ b/src/components/layout/styled.tsx
@@ -236,6 +236,7 @@ export const PageHeaderWrapper = styled.div<{
   imageHeight: string;
   isDark?: boolean;
 }>`
+  user-select: none;
   display: ${(props) => (props.hasImage ? 'inline-block' : 'undefined')};
   width: ${(props) => (props.hasImage ? `calc(100% - ${props.imageHeight + 15}px)` : '100%')};
   margin-left: ${(props) => (props.hasImage ? '15px' : '0px')};

--- a/src/components/library/AlbumList.tsx
+++ b/src/components/library/AlbumList.tsx
@@ -451,11 +451,6 @@ const AlbumList = () => {
           handleRowClick={handleRowClick}
           handleRowDoubleClick={handleRowDoubleClick}
           handleRating={handleRowRating}
-          cacheImages={{
-            enabled: settings.getSync('cacheImages'),
-            cacheType: 'album',
-            cacheIdProperty: 'albumId',
-          }}
           page="albumListPage"
           listType="album"
           virtualized

--- a/src/components/library/AlbumView.tsx
+++ b/src/components/library/AlbumView.tsx
@@ -44,7 +44,6 @@ import {
   formatDuration,
   getAlbumSize,
   getPlayedSongsNotification,
-  isCached,
 } from '../../shared/utils';
 import {
   LinkWrapper,
@@ -298,13 +297,7 @@ const AlbumView = ({ ...rest }: any) => {
             // which causes the background-image to flicker
             expanded={misc.expandSidebar}
             style={{
-              backgroundImage: `url(${
-                !data?.image.match('placeholder')
-                  ? isCached(`${misc.imageCachePath}album_${albumId}.jpg`)
-                    ? `${misc.imageCachePath}album_${albumId}.jpg`.replaceAll('\\', '/')
-                    : data.image
-                  : 'null'
-              })`,
+              backgroundImage: `url(${!data?.image.match('placeholder') ? data.image : 'null'})`,
             }}
           />
         </BlurredBackgroundWrapper>
@@ -319,11 +312,7 @@ const AlbumView = ({ ...rest }: any) => {
               <Card
                 title="None"
                 subtitle=""
-                coverArt={
-                  isCached(`${misc.imageCachePath}album_${albumId}.jpg`)
-                    ? `${misc.imageCachePath}album_${albumId}.jpg`
-                    : data.image
-                }
+                coverArt={data.image}
                 size={200}
                 hasHoverButtons
                 noInfoPanel
@@ -334,11 +323,6 @@ const AlbumView = ({ ...rest }: any) => {
                 handleFavorite={handleFavorite}
               />
             }
-            cacheImages={{
-              enabled: settings.getSync('cacheImages'),
-              cacheType: 'album',
-              id: data.albumId,
-            }}
             imageHeight={200}
             title={data.title}
             showTitleTooltip
@@ -560,11 +544,6 @@ const AlbumView = ({ ...rest }: any) => {
           virtualized
           rowHeight={Number(settings.getSync('musicListRowHeight'))}
           fontSize={Number(settings.getSync('musicListFontSize'))}
-          cacheImages={{
-            enabled: settings.getSync('cacheImages'),
-            cacheType: 'album',
-            cacheIdProperty: 'albumId',
-          }}
           page="albumPage"
           listType="music"
           isModal={rest.isModal}

--- a/src/components/library/ArtistList.tsx
+++ b/src/components/library/ArtistList.tsx
@@ -224,11 +224,6 @@ const ArtistList = () => {
           handleRowClick={handleRowClick}
           handleRowDoubleClick={handleRowDoubleClick}
           handleRating={handleRowRating}
-          cacheImages={{
-            enabled: settings.getSync('cacheImages'),
-            cacheType: 'artist',
-            cacheIdProperty: 'id',
-          }}
           page="artistListPage"
           listType="artist"
           virtualized

--- a/src/components/library/ArtistView.tsx
+++ b/src/components/library/ArtistView.tsx
@@ -38,12 +38,7 @@ import {
   setRate,
 } from '../../redux/playQueueSlice';
 import { notifyToast } from '../shared/toast';
-import {
-  filterPlayQueue,
-  formatDuration,
-  getPlayedSongsNotification,
-  isCached,
-} from '../../shared/utils';
+import { filterPlayQueue, formatDuration, getPlayedSongsNotification } from '../../shared/utils';
 import {
   LinkWrapper,
   SectionTitle,
@@ -467,9 +462,7 @@ const ArtistView = ({ ...rest }: any) => {
 
   useEffect(() => {
     if (!isLoading) {
-      const img = isCached(`${misc.imageCachePath}artist_${data?.id}.jpg`)
-        ? `${misc.imageCachePath}artist_${data?.id}.jpg`
-        : data?.image?.includes('placeholder')
+      const img = data?.image?.includes('placeholder')
         ? data?.info?.imageUrl
           ? data?.info?.imageUrl
           : data?.image
@@ -503,7 +496,7 @@ const ArtistView = ({ ...rest }: any) => {
       };
       setAvgColor(img);
     }
-  }, [data?.id, data?.image, data?.info, isLoading, misc.imageCachePath]);
+  }, [data?.id, data?.image, data?.info, isLoading]);
 
   useEffect(() => {
     const allAlbumDurations = _.sum(_.map(data?.album, 'duration'));
@@ -545,9 +538,7 @@ const ArtistView = ({ ...rest }: any) => {
                 title={t('None')}
                 subtitle=""
                 coverArt={
-                  isCached(`${misc.imageCachePath}artist_${data?.id}.jpg`)
-                    ? `${misc.imageCachePath}artist_${data?.id}.jpg`
-                    : data?.image?.includes('placeholder')
+                  data?.image?.includes('placeholder')
                     ? data?.info?.imageUrl
                       ? data?.info?.imageUrl
                       : data?.image
@@ -565,11 +556,6 @@ const ArtistView = ({ ...rest }: any) => {
                 handleFavorite={handleFavorite}
               />
             }
-            cacheImages={{
-              enabled: settings.getSync('cacheImages'),
-              cacheType: 'artist',
-              id: data.id,
-            }}
             imageHeight={
               location.pathname.match('/songs|/albums|/compilationalbums|/topsongs') ? 180 : 225
             }
@@ -751,7 +737,7 @@ const ArtistView = ({ ...rest }: any) => {
                         </StyledPopover>
                       }
                     >
-                      <CustomTooltip text="{t('Info')}">
+                      <CustomTooltip text={t('Info')}>
                         <StyledButton appearance="subtle" size="lg">
                           <Icon icon="info-circle" />
                         </StyledButton>
@@ -778,11 +764,6 @@ const ArtistView = ({ ...rest }: any) => {
               virtualized
               rowHeight={config.lookAndFeel.listView.music.rowHeight}
               fontSize={config.lookAndFeel.listView.music.fontSize}
-              cacheImages={{
-                enabled: settings.getSync('cacheImages'),
-                cacheType: 'album',
-                cacheIdProperty: 'albumId',
-              }}
               listType="music"
               dnd
               disabledContextMenuOptions={['deletePlaylist', 'viewInModal']}
@@ -810,11 +791,6 @@ const ArtistView = ({ ...rest }: any) => {
                   virtualized
                   rowHeight={config.lookAndFeel.listView.album.rowHeight}
                   fontSize={config.lookAndFeel.listView.album.fontSize}
-                  cacheImages={{
-                    enabled: settings.getSync('cacheImages'),
-                    cacheType: 'album',
-                    cacheIdProperty: 'albumId',
-                  }}
                   page="artistPage"
                   listType="album"
                   isModal={rest.isModal}
@@ -863,11 +839,6 @@ const ArtistView = ({ ...rest }: any) => {
               virtualized
               rowHeight={config.lookAndFeel.listView.music.rowHeight}
               fontSize={config.lookAndFeel.listView.music.fontSize}
-              cacheImages={{
-                enabled: settings.getSync('cacheImages'),
-                cacheType: 'album',
-                cacheIdProperty: 'albumId',
-              }}
               listType="music"
               dnd
               disabledContextMenuOptions={['deletePlaylist', 'viewInModal']}
@@ -934,7 +905,6 @@ const ArtistView = ({ ...rest }: any) => {
                     rowHeight={config.lookAndFeel.listView.music.rowHeight}
                     fontSize={config.lookAndFeel.listView.music.fontSize}
                     listType="music"
-                    cacheImages={{ enabled: false }}
                     isModal={false}
                     miniView={false}
                     handleFavorite={(rowData: any) =>

--- a/src/components/library/FolderList.tsx
+++ b/src/components/library/FolderList.tsx
@@ -245,11 +245,6 @@ const FolderList = () => {
               handleRowDoubleClick={handleRowDoubleClick}
               handleFavorite={handleRowFavorite}
               handleRating={handleRowRating}
-              cacheImages={{
-                enabled: settings.getSync('cacheImages'),
-                cacheType: 'folder',
-                cacheIdProperty: 'albumId',
-              }}
               page="folderListPage"
               listType="folder"
               virtualized

--- a/src/components/library/MusicList.tsx
+++ b/src/components/library/MusicList.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
 import _ from 'lodash';
-import settings from 'electron-settings';
 import { ButtonToolbar } from 'rsuite';
 import { useQuery, useQueryClient } from 'react-query';
 import { useTranslation } from 'react-i18next';
@@ -313,11 +312,6 @@ const MusicList = () => {
           handleRowClick={handleRowClick}
           handleRowDoubleClick={handleRowDoubleClick}
           handleRating={handleRowRating}
-          cacheImages={{
-            enabled: settings.getSync('cacheImages'),
-            cacheType: 'album',
-            cacheIdProperty: 'albumId',
-          }}
           page="musicListPage"
           listType="music"
           virtualized

--- a/src/components/player/NowPlayingMiniView.tsx
+++ b/src/components/player/NowPlayingMiniView.tsx
@@ -506,11 +506,6 @@ const NowPlayingMiniView = () => {
               virtualized
               rowHeight={config.lookAndFeel.listView.mini.rowHeight}
               fontSize={config.lookAndFeel.listView.mini.fontSize}
-              cacheImages={{
-                enabled: settings.getSync('cacheImages'),
-                cacheType: 'album',
-                cacheIdProperty: 'albumId',
-              }}
               listType="music"
               miniView
               nowPlaying

--- a/src/components/player/NowPlayingView.tsx
+++ b/src/components/player/NowPlayingView.tsx
@@ -535,11 +535,6 @@ const NowPlayingView = () => {
           virtualized
           rowHeight={config.lookAndFeel.listView.music.rowHeight}
           fontSize={config.lookAndFeel.listView.music.fontSize}
-          cacheImages={{
-            enabled: settings.getSync('cacheImages'),
-            cacheType: 'album',
-            cacheIdProperty: 'albumId',
-          }}
           listType="music"
           nowPlaying
           dnd

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -251,22 +251,22 @@ const Player = ({ currentEntryList, muted, children }: any, ref: any) => {
   const [scrobbled, setScrobbled] = useState(false);
 
   const getSrc1 = useCallback(() => {
-    const cachedSongPath = `${misc.imageCachePath}/${
+    const cachedSongPath = `${misc.songCachePath}/${
       playQueue[currentEntryList][playQueue.player1.index]?.id
     }.mp3`;
     return isCached(cachedSongPath)
       ? cachedSongPath
       : playQueue[currentEntryList][playQueue.player1.index]?.streamUrl;
-  }, [misc.imageCachePath, currentEntryList, playQueue]);
+  }, [misc.songCachePath, currentEntryList, playQueue]);
 
   const getSrc2 = useCallback(() => {
-    const cachedSongPath = `${misc.imageCachePath}/${
+    const cachedSongPath = `${misc.songCachePath}/${
       playQueue[currentEntryList][playQueue.player2.index]?.id
     }.mp3`;
     return isCached(cachedSongPath)
       ? cachedSongPath
       : playQueue[currentEntryList][playQueue.player2.index]?.streamUrl;
-  }, [misc.imageCachePath, currentEntryList, playQueue]);
+  }, [misc.songCachePath, currentEntryList, playQueue]);
 
   useImperativeHandle(ref, () => ({
     get player1() {

--- a/src/components/player/PlayerBar.tsx
+++ b/src/components/player/PlayerBar.tsx
@@ -36,12 +36,7 @@ import CustomTooltip from '../shared/CustomTooltip';
 import placeholderImg from '../../img/placeholder.png';
 import DebugWindow from '../debug/DebugWindow';
 import { CoverArtWrapper } from '../layout/styled';
-import {
-  decodeBase64Image,
-  getCurrentEntryList,
-  isCached,
-  writeOBSFiles,
-} from '../../shared/utils';
+import { decodeBase64Image, getCurrentEntryList, writeOBSFiles } from '../../shared/utils';
 import { StyledPopover } from '../shared/styled';
 import { apiController } from '../../api/controller';
 import { Artist, Server } from '../../types';
@@ -55,7 +50,6 @@ const PlayerBar = () => {
   const queryClient = useQueryClient();
   const playQueue = useAppSelector((state) => state.playQueue);
   const player = useAppSelector((state) => state.player);
-  const misc = useAppSelector((state) => state.misc);
   const config = useAppSelector((state) => state.config);
   const dispatch = useAppDispatch();
   const [seek, setSeek] = useState(0);
@@ -562,20 +556,12 @@ const PlayerBar = () => {
                             <CoverArtWrapper size={500}>
                               <LazyLoadImage
                                 src={
-                                  isCached(
-                                    `${misc.imageCachePath}album_${
-                                      playQueue[currentEntryList][playQueue.currentIndex]?.albumId
-                                    }.jpg`
-                                  )
-                                    ? `${misc.imageCachePath}album_${
-                                        playQueue[currentEntryList][playQueue.currentIndex]?.albumId
-                                      }.jpg`
-                                    : playQueue[currentEntryList][
-                                        playQueue.currentIndex
-                                      ]?.image.replace(
-                                        /&size=\d+|width=\d+&height=\d+&quality=\d+/,
-                                        ''
-                                      ) || placeholderImg
+                                  playQueue[currentEntryList][
+                                    playQueue.currentIndex
+                                  ]?.image.replace(
+                                    /&size=\d+|width=\d+&height=\d+&quality=\d+/,
+                                    ''
+                                  ) || placeholderImg
                                 }
                                 height={500}
                               />
@@ -587,16 +573,8 @@ const PlayerBar = () => {
                       <CoverArtWrapper size={65}>
                         <LazyLoadImage
                           src={
-                            isCached(
-                              `${misc.imageCachePath}album_${
-                                playQueue[currentEntryList][playQueue.currentIndex]?.albumId
-                              }.jpg`
-                            )
-                              ? `${misc.imageCachePath}album_${
-                                  playQueue[currentEntryList][playQueue.currentIndex]?.albumId
-                                }.jpg`
-                              : playQueue[currentEntryList][playQueue.currentIndex]?.image ||
-                                placeholderImg
+                            playQueue[currentEntryList][playQueue.currentIndex]?.image ||
+                            placeholderImg
                           }
                           tabIndex={0}
                           onClick={() => history.push(`/nowplaying`)}

--- a/src/components/playlist/PlaylistList.tsx
+++ b/src/components/playlist/PlaylistList.tsx
@@ -229,11 +229,6 @@ const PlaylistList = () => {
           tableColumns={config.lookAndFeel.listView.playlist.columns}
           rowHeight={config.lookAndFeel.listView.playlist.rowHeight}
           fontSize={config.lookAndFeel.listView.playlist.fontSize}
-          cacheImages={{
-            enabled: settings.getSync('cacheImages'),
-            cacheType: 'playlist',
-            cacheIdProperty: 'id',
-          }}
           page="playlistListPage"
           listType="playlist"
           virtualized

--- a/src/components/playlist/PlaylistView.tsx
+++ b/src/components/playlist/PlaylistView.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState, useRef } from 'react';
 import _ from 'lodash';
 import fs from 'fs';
 import path from 'path';
-import settings from 'electron-settings';
 import { ButtonToolbar, ControlLabel, Form, Whisper } from 'rsuite';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useQuery, useQueryClient } from 'react-query';
@@ -44,7 +43,6 @@ import {
   getPlayedSongsNotification,
   getRecoveryPath,
   getUniqueRandomNumberArr,
-  isCached,
   isFailedResponse,
 } from '../../shared/utils';
 import useSearchQuery from '../../hooks/useSearchQuery';
@@ -509,13 +507,7 @@ const PlaylistView = ({ ...rest }) => {
             <Card
               title={t('None')}
               subtitle=""
-              coverArt={
-                data?.image.match('placeholder')
-                  ? customPlaylistImage
-                  : isCached(`${misc.imageCachePath}playlist_${playlistId}.jpg`)
-                  ? `${misc.imageCachePath}playlist_${playlistId}.jpg`
-                  : data.image
-              }
+              coverArt={data?.image.match('placeholder') ? customPlaylistImage : data.image}
               size={185}
               hasHoverButtons
               noInfoPanel
@@ -525,11 +517,6 @@ const PlaylistView = ({ ...rest }) => {
               url={`/playlist/${data.id}`}
             />
           }
-          cacheImages={{
-            enabled: settings.getSync('cacheImages'),
-            cacheType: 'playlist',
-            id: data.id,
-          }}
           imageHeight={185}
           title={data.title}
           subtitle={
@@ -711,11 +698,6 @@ const PlaylistView = ({ ...rest }) => {
         virtualized
         rowHeight={config.lookAndFeel.listView.music.rowHeight}
         fontSize={config.lookAndFeel.listView.music.fontSize}
-        cacheImages={{
-          enabled: settings.getSync('cacheImages'),
-          cacheType: 'album',
-          cacheIdProperty: 'albumId',
-        }}
         listType="music"
         playlist
         dnd

--- a/src/components/scrollingmenu/ScrollingMenu.tsx
+++ b/src/components/scrollingmenu/ScrollingMenu.tsx
@@ -1,5 +1,4 @@
 import React, { useRef } from 'react';
-import settings from 'electron-settings';
 import styled from 'styled-components';
 import { ButtonGroup, ButtonToolbar, FlexboxGrid, Icon } from 'rsuite';
 import Card from '../card/Card';
@@ -27,8 +26,6 @@ const ScrollingMenu = ({
   handleFavorite,
   noScrollbar,
 }: any) => {
-  const cacheImages = Boolean(settings.getSync('cacheImages'));
-  const misc = useAppSelector((state) => state.misc);
   const config = useAppSelector((state) => state.config);
   const scrollContainerRef = useRef<any>();
 
@@ -120,8 +117,6 @@ const ScrollingMenu = ({
               hasHoverButtons
               size={config.lookAndFeel.gridView.cardSize}
               lazyLoad
-              cacheImages={cacheImages}
-              cachePath={misc.imageCachePath}
               style={{ margin: '5px' }}
               handleFavorite={handleFavorite}
             />

--- a/src/components/search/SearchView.tsx
+++ b/src/components/search/SearchView.tsx
@@ -261,11 +261,6 @@ const SearchView = () => {
               handleRowDoubleClick={handleRowDoubleClick}
               handleRating={handleRowRating}
               listType="music"
-              cacheImages={{
-                enabled: settings.getSync('cacheImages'),
-                cacheType: 'album',
-                cacheIdProperty: 'albumId',
-              }}
               disabledContextMenuOptions={['deletePlaylist', 'viewInModal']}
               playQueue={playQueue}
               multiSelect={multiSelect}

--- a/src/components/settings/ConfigPanels/CacheConfig.tsx
+++ b/src/components/settings/ConfigPanels/CacheConfig.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import settings from 'electron-settings';
-import { shell } from 'electron';
+import { shell, remote } from 'electron';
 import fs from 'fs';
 import path from 'path';
 import { Message, Icon, ButtonToolbar, Whisper } from 'rsuite';
@@ -26,25 +26,20 @@ const fsUtils = require('nodejs-fs-utils');
 const CacheConfig = ({ bordered }: any) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const [imgCacheSize, setImgCacheSize] = useState(0);
   const [songCacheSize, setSongCacheSize] = useState(0);
   const [isEditingCachePath, setIsEditingCachePath] = useState(false);
   const [newCachePath, setNewCachePath] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [cacheSongs, setCacheSongs] = useState(Boolean(settings.getSync('cacheSongs')));
-  const [cacheImages, setCacheImages] = useState(Boolean(settings.getSync('cacheImages')));
+  const [cacheImages] = useState(true);
 
   useEffect(() => {
     // Retrieve cache sizes on render
     try {
-      setImgCacheSize(Number((fsUtils.fsizeSync(getImageCachePath()) / 1000 / 1000).toFixed(0)));
-
       setSongCacheSize(Number((fsUtils.fsizeSync(getSongCachePath()) / 1000 / 1000).toFixed(0)));
     } catch (err) {
-      setImgCacheSize(0);
       setSongCacheSize(0);
       fs.mkdirSync(getSongCachePath(), { recursive: true });
-      fs.mkdirSync(getImageCachePath(), { recursive: true });
     }
   }, []);
 
@@ -72,36 +67,10 @@ const CacheConfig = ({ bordered }: any) => {
     notifyToast('success', t('Cleared song cache'));
   };
 
-  const handleClearImageCache = (type: 'playlist' | 'album' | 'artist' | 'folder') => {
-    const imageCachePath = getImageCachePath();
-    fs.readdir(imageCachePath, (err, files) => {
-      if (err) {
-        return notifyToast('error', t('Unable to scan directory: {{err}}', { err }));
-      }
-
-      const selectedFiles =
-        type === 'playlist'
-          ? files.filter((file) => file.split('_')[0] === 'playlist')
-          : type === 'album'
-          ? files.filter((file) => file.split('_')[0] === 'album')
-          : type === 'folder'
-          ? files.filter((file) => file.split('_')[0] === 'folder')
-          : files.filter((file) => file.split('_')[0] === 'artist');
-
-      return selectedFiles.forEach((file) => {
-        const imagePath = path.join(imageCachePath, file);
-
-        // Simple validation
-        if (path.extname(imagePath) === '.jpg') {
-          fs.unlink(imagePath, (error) => {
-            if (err) {
-              return notifyToast('error', t('Unable to clear cache item: {{error}}', { error }));
-            }
-            return null;
-          });
-        }
-      });
-    });
+  const handleClearImageCache = () => {
+    const type = 'album';
+    const win = remote.getCurrentWindow();
+    win.webContents.session.clearCache();
     notifyToast('success', t('Cleared {{type}} image cache', { type }));
   };
 
@@ -193,20 +162,11 @@ const CacheConfig = ({ bordered }: any) => {
         >
           {t('Songs')}{' '}
           <StyledTag>
-            {songCacheSize} MB {imgCacheSize === 9999999 && t('- Folder not found')}
+            {songCacheSize} MB {songCacheSize === 9999999 && t('- Folder not found')}
           </StyledTag>
         </StyledCheckbox>
-        <StyledCheckbox
-          defaultChecked={cacheImages}
-          onChange={(_v: any, e: boolean) => {
-            settings.setSync('cacheImages', e);
-            setCacheImages(e);
-          }}
-        >
-          {t('Images')}{' '}
-          <StyledTag>
-            {imgCacheSize} MB {imgCacheSize === 9999999 && t('- Folder not found')}
-          </StyledTag>
+        <StyledCheckbox defaultChecked={cacheImages} disabled={cacheImages}>
+          {t('Images')}
         </StyledCheckbox>
       </div>
       <br />
@@ -224,17 +184,8 @@ const CacheConfig = ({ bordered }: any) => {
                 <StyledButton size="sm" onClick={handleClearSongCache}>
                   {t('Songs')}
                 </StyledButton>
-                <StyledButton size="sm" onClick={() => handleClearImageCache('playlist')}>
-                  {t('Playlist images')}
-                </StyledButton>
-                <StyledButton size="sm" onClick={() => handleClearImageCache('album')}>
-                  {t('Album images')}
-                </StyledButton>
-                <StyledButton size="sm" onClick={() => handleClearImageCache('artist')}>
-                  {t('Artist images')}
-                </StyledButton>
-                <StyledButton size="sm" onClick={() => handleClearImageCache('folder')}>
-                  {t('Folder images')}
+                <StyledButton size="sm" onClick={() => handleClearImageCache()}>
+                  {t('Images')}
                 </StyledButton>
               </ButtonToolbar>
             </StyledPopover>

--- a/src/components/settings/ConfigPanels/ListViewConfig.tsx
+++ b/src/components/settings/ConfigPanels/ListViewConfig.tsx
@@ -180,7 +180,6 @@ const ListViewConfig = ({
             rowHeight={35}
             fontSize={12}
             listType="column"
-            cacheImages={{ enabled: false }}
             playQueue={playQueue}
             multiSelect={multiSelect}
             isModal={false}

--- a/src/components/settings/ConfigPanels/PlayerConfig.tsx
+++ b/src/components/settings/ConfigPanels/PlayerConfig.tsx
@@ -352,7 +352,7 @@ const PlayerConfig = ({ bordered }: any) => {
           rowHeight={35}
           fontSize={12}
           listType="column"
-          cacheImages={{ enabled: false }}
+          s={{ enabled: false }}
           playQueue={playQueue}
           multiSelect={multiSelect}
           isModal={false}

--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -179,10 +179,6 @@ const setDefaultSettings = (force: boolean) => {
     settings.setSync('scrollWithCurrentSong', true);
   }
 
-  if (force || !settings.hasSync('cacheImages')) {
-    settings.setSync('cacheImages', true);
-  }
-
   if (force || !settings.hasSync('cacheSongs')) {
     settings.setSync('cacheSongs', false);
   }

--- a/src/components/starred/StarredView.tsx
+++ b/src/components/starred/StarredView.tsx
@@ -332,11 +332,6 @@ const StarredView = () => {
               handleRating={handleRowRating}
               rowHeight={config.lookAndFeel.listView.music.rowHeight}
               fontSize={config.lookAndFeel.listView.music.fontSize}
-              cacheImages={{
-                enabled: settings.getSync('cacheImages'),
-                cacheType: 'album',
-                cacheIdProperty: 'albumId',
-              }}
               page="favoriteTracksPage"
               listType="music"
               virtualized
@@ -364,11 +359,6 @@ const StarredView = () => {
                   handleRowClick={handleRowClick}
                   handleRowDoubleClick={handleRowDoubleClick}
                   handleRating={handleRowRating}
-                  cacheImages={{
-                    enabled: settings.getSync('cacheImages'),
-                    cacheType: 'album',
-                    cacheIdProperty: 'albumId',
-                  }}
                   page="favoriteAlbumsPage"
                   listType="album"
                   virtualized
@@ -424,11 +414,6 @@ const StarredView = () => {
                   handleRowClick={handleRowClick}
                   handleRowDoubleClick={handleRowDoubleClick}
                   handleRating={handleRowRating}
-                  cacheImages={{
-                    enabled: false,
-                    cacheType: 'artist',
-                    cacheIdProperty: 'id',
-                  }}
                   page="favoriteArtistsPage"
                   listType="artist"
                   virtualized

--- a/src/components/viewtypes/GridViewType.tsx
+++ b/src/components/viewtypes/GridViewType.tsx
@@ -1,6 +1,5 @@
 // Referenced from: https://codesandbox.io/s/jjkz5y130w?file=/index.js:700-703
 import React, { useEffect, useMemo, useState } from 'react';
-import settings from 'electron-settings';
 import { FixedSizeList as List } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import Card from '../card/Card';
@@ -54,8 +53,6 @@ const GridCard = ({ data, index, style }: any) => {
             id: data.data[i][data.playClick.idProperty],
           }}
           details={{ cacheType: data.cacheType, ...data.data[i] }}
-          cacheImages={data.cacheImages}
-          cachePath={data.cachePath}
           handleFavorite={data.handleFavorite}
           musicFolderId={data.musicFolderId}
         />
@@ -89,8 +86,6 @@ function ListWrapper({
   itemCount,
   width,
   cacheType,
-  cacheImages,
-  cachePath,
   handleFavorite,
   musicFolderId,
   initialScrollOffset,
@@ -117,8 +112,6 @@ function ListWrapper({
       cardWidth,
       cardHeight,
       gapSize,
-      cacheImages,
-      cachePath,
       handleFavorite,
       musicFolderId,
     }),
@@ -135,8 +128,6 @@ function ListWrapper({
       size,
       gapSize,
       alignment,
-      cacheImages,
-      cachePath,
       handleFavorite,
       musicFolderId,
     ]
@@ -178,8 +169,6 @@ const GridViewType = ({
   loading,
   gridRef,
 }: any) => {
-  const cacheImages = Boolean(settings.getSync('cacheImages'));
-  const misc = useAppSelector((state) => state.misc);
   const config = useAppSelector((state) => state.config);
   const folder = useAppSelector((state) => state.folder);
   const [musicFolder, setMusicFolder] = useState(undefined);
@@ -210,8 +199,6 @@ const GridViewType = ({
                 gapSize={config.lookAndFeel.gridView.gapSize}
                 alignment={config.lookAndFeel.gridView.alignment}
                 cacheType={cacheType}
-                cacheImages={cacheImages}
-                cachePath={misc.imageCachePath}
                 handleFavorite={handleFavorite}
                 musicFolderId={musicFolder}
                 initialScrollOffset={initialScrollOffset}

--- a/src/components/viewtypes/ListViewTable.tsx
+++ b/src/components/viewtypes/ListViewTable.tsx
@@ -16,13 +16,7 @@ import {
   StyledTableHeaderCell,
   TableCellWrapper,
 } from './styled';
-import {
-  formatSongDuration,
-  isCached,
-  formatDate,
-  convertByteToMegabyte,
-} from '../../shared/utils';
-import cacheImage from '../shared/cacheImage';
+import { formatSongDuration, formatDate, convertByteToMegabyte } from '../../shared/utils';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import {
   fixPlayer2Index,
@@ -106,7 +100,6 @@ const ListViewTable = ({
   columns,
   handleRowClick,
   handleRowDoubleClick,
-  cacheImages,
   autoHeight,
   page,
   listType,
@@ -666,32 +659,11 @@ const ListViewTable = ({
                           >
                             <CoverArtWrapper size={rowHeight - 10}>
                               <LazyLoadImage
-                                src={
-                                  isCached(
-                                    `${misc.imageCachePath}${cacheImages.cacheType}_${
-                                      rowData[cacheImages.cacheIdProperty]
-                                    }.jpg`
-                                  )
-                                    ? `${misc.imageCachePath}${cacheImages.cacheType}_${
-                                        rowData[cacheImages.cacheIdProperty]
-                                      }.jpg`
-                                    : rowData.image
-                                }
+                                src={rowData.image}
                                 alt="track-img"
-                                effect="opacity"
                                 width={rowHeight - 10}
                                 height={rowHeight - 10}
                                 visibleByDefault
-                                afterLoad={() => {
-                                  if (cacheImages.enabled) {
-                                    cacheImage(
-                                      `${cacheImages.cacheType}_${
-                                        rowData[cacheImages.cacheIdProperty]
-                                      }.jpg`,
-                                      rowData.image.replaceAll(/=150/gi, '=350')
-                                    );
-                                  }
-                                }}
                               />
                             </CoverArtWrapper>
                           </Col>
@@ -846,32 +818,11 @@ const ListViewTable = ({
                     >
                       <CoverArtWrapper size={rowHeight - 10}>
                         <LazyLoadImage
-                          src={
-                            isCached(
-                              `${misc.imageCachePath}${cacheImages.cacheType}_${
-                                rowData[cacheImages.cacheIdProperty]
-                              }.jpg`
-                            )
-                              ? `${misc.imageCachePath}${cacheImages.cacheType}_${
-                                  rowData[cacheImages.cacheIdProperty]
-                                }.jpg`
-                              : rowData.image
-                          }
+                          src={rowData.image}
                           alt="track-img"
-                          effect="opacity"
                           width={rowHeight - 10}
                           height={rowHeight - 10}
                           visibleByDefault
-                          afterLoad={() => {
-                            if (cacheImages.enabled) {
-                              cacheImage(
-                                `${cacheImages.cacheType}_${
-                                  rowData[cacheImages.cacheIdProperty]
-                                }.jpg`,
-                                rowData.image.replaceAll(/=150/gi, '=350')
-                              );
-                            }
-                          }}
                         />
                       </CoverArtWrapper>
                     </TableCellWrapper>

--- a/src/components/viewtypes/ListViewType.tsx
+++ b/src/components/viewtypes/ListViewType.tsx
@@ -23,7 +23,6 @@ const ListViewType = (
     rowHeight,
     virtualized,
     fontSize,
-    cacheImages,
     children,
     page,
     listType,
@@ -348,7 +347,6 @@ const ListViewType = (
             columns={tableColumns}
             handleRowClick={handleRowClick}
             handleRowDoubleClick={handleRowDoubleClick}
-            cacheImages={cacheImages}
             page={page}
             listType={listType}
             nowPlaying={rest.nowPlaying}


### PR DESCRIPTION
## On hold due to future offline-mode implementation

- Use default electron caching
- Should improve application performance on list/grid views scroll

Previously the app was using a custom caching solution by using javascript to automatically check, download, and use cached images on/to the local disk.