### PR TITLE
Fix macOS window exit behaviour

### DIFF
--- a/src/main.dev.js
+++ b/src/main.dev.js
@@ -757,7 +757,9 @@ app.on('window-all-closed', () => {
   // Respect the OSX convention of having the application in memory even
   // after all windows have been closed
   globalShortcut.unregisterAll();
-  if (process.platform !== 'darwin') {
+  if (process.platform === 'darwin') {
+    mainWindow = null;
+  } else {
     app.quit();
   }
 });
@@ -776,7 +778,11 @@ app
 app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) createWindow();
+  if (mainWindow === null) {
+    createWindow();
+  } else {
+    mainWindow.show();
+  }
 });
 
 ipcMain.on('reload', () => {


### PR DESCRIPTION
I think these are the changes that need to be made to close #197

### Fix demos
**Fix demo 1:**
Fix with 'Exit to Tray' set to `FALSE`
![fix_exit_tray_off_r](https://user-images.githubusercontent.com/2040617/150191037-28e26bff-d97a-41c2-a87b-a5e0873693a3.gif)

**Fix demo 2:**
Fix with 'Exit to Tray' set to `TRUE`
![fix_exit_tray_on_r](https://user-images.githubusercontent.com/2040617/150191335-b5e22a25-e8b7-4802-a2bb-b1802b1b68ab.gif)

**Side note:** With this fix applied `Exit to Tray` set to `TRUE` is a much better experience in macOS, potentially having this set to 'TRUE' in the mac release by default could be considered for the future?
