### PR TITLE
select search text on search focus

### DIFF
--- a/src/components/layout/GenericPageHeader.tsx
+++ b/src/components/layout/GenericPageHeader.tsx
@@ -181,7 +181,7 @@ const GenericPageHeader = ({
                     onClick={() => {
                       setOpenSearch(true);
                       setTimeout(() => {
-                        document.getElementById('local-search-input')?.focus();
+                        document.getElementById('local-search-input')?.select();
                       }, 50);
                     }}
                     appearance="subtle"

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -51,7 +51,7 @@ const Layout = ({ footer, children, disableSidebar, font }: any) => {
 
   useHotkeys('ctrl+f', () => {
     setOpenSearch(true);
-    document.getElementById('local-search-input')?.focus();
+    document.getElementById('local-search-input')?.select();
   });
 
   const handleToggle = () => {
@@ -218,7 +218,7 @@ const Layout = ({ footer, children, disableSidebar, font }: any) => {
                       onClick={() => {
                         setOpenSearch(true);
                         setTimeout(() => {
-                          document.getElementById('local-search-input')?.focus();
+                          document.getElementById('local-search-input')?.select();
                         }, 50);
                       }}
                       appearance="subtle"


### PR DESCRIPTION
Super simple change, simply selects any existing text within the search box when focused.

Functionality at the moment is to just give focus, but the previous search is left in the search box and requires backspacing to execute a fresh search.