### PR TITLE
Adjust Jellyfin scrobble to match default behavior

### DIFF
--- a/src/api/jellyfinApi.ts
+++ b/src/api/jellyfinApi.ts
@@ -769,7 +769,7 @@ export const scrobble = async (options: {
   id: string;
   submission: boolean;
   position?: number;
-  event?: 'pause' | 'unpause' | 'timeupdate';
+  event?: 'pause' | 'unpause' | 'timeupdate' | 'start';
 }) => {
   if (options.submission) {
     // Checked by jellyfin-plugin-lastfm for whether or not to send the "finished" scrobble (uses PositionTicks)
@@ -778,16 +778,16 @@ export const scrobble = async (options: {
       IsPaused: true,
       PositionTicks: options.position && Math.round(options.position),
     });
-
-    // Marks the item as played on Jellyfin and adds +1 to the play count for the item (songs only)
-    return jellyfinApi.post(`/users/${auth.username}/playeditems/${options.id}`, null, {
-      params: {
-        datePlayed: moment().format(),
-      },
-    });
   }
 
   if (options.event) {
+    if (options.event === 'start') {
+      return jellyfinApi.post(`/sessions/playing`, {
+        ItemId: options.id,
+        PositionTicks: options.position && Math.round(options.position),
+      });
+    }
+
     return jellyfinApi.post(`/sessions/playing/progress`, {
       ItemId: options.id,
       EventName: options.event,

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -551,6 +551,24 @@ const Player = ({ currentEntryList, muted, children }: any, ref: any) => {
               },
             });
           }, 1000);
+
+          if (config.serverType === Server.Jellyfin && currentSeek < 1) {
+            setTimeout(() => {
+              apiController({
+                serverType: config.serverType,
+                endpoint: 'scrobble',
+                args: {
+                  id:
+                    playerNumber === 1
+                      ? playQueue[currentEntryList][playQueue.player1.index]?.id
+                      : playQueue[currentEntryList][playQueue.player2.index]?.id,
+                  submission: false,
+                  position: currentSeek * 10000000,
+                  event: 'start',
+                },
+              });
+            }, 1000);
+          }
         }
       }
     },

--- a/src/redux/playQueueSlice.ts
+++ b/src/redux/playQueueSlice.ts
@@ -689,6 +689,8 @@ const playQueueSlice = createSlice({
       // Used with gridview where you just want to set the entry queue directly
       resetPlayerDefaults(state);
 
+      state.player1.src = action.payload.entries[0].streamUrl;
+
       action.payload.entries.map((entry: any) => state.entry.push(entry));
       if (state.shuffle) {
         // If shuffle is enabled, add all entries randomly
@@ -719,6 +721,8 @@ const playQueueSlice = createSlice({
       // Setting the entry queue by row will add all entries, but set the current index to
       // the row that was double clicked
       resetPlayerDefaults(state);
+
+      state.player1.src = action.payload.entries[action.payload.currentIndex].streamUrl;
 
       // Apply filters to all entries except the entry that was double clicked
       const filteredFromStartToCurrent = filterPlayQueue(


### PR DESCRIPTION
Closes #187 

Changes Jellyfin scrobbling back to use `/sessions/playing` request on song start.

Resolves:
- Functionality with [Jellyfin Playback Reporting Plugin](https://github.com/jellyfin/jellyfin-plugin-playbackreporting)
- Fixed bug causing multiple play count increments on song start (#126)

Consequences:
- Song play count incremented by 1 immediately when the song begins playing instead of when it is "completed" (4 minutes / 90%)