### PR TITLE
Optimize list view table

### DIFF
--- a/src/components/layout/styled.tsx
+++ b/src/components/layout/styled.tsx
@@ -212,7 +212,7 @@ export const SidebarNavItem = styled(Nav.Item)<{ hide?: boolean }>`
 export const CoverArtWrapper = styled.div<{ $link?: boolean; size: number; card?: boolean }>`
   display: inline-block;
   filter: ${(props) => props.theme.other.coverArtFilter};
-  cursor: ${(props) => (props.$link ? 'pointer' : 'default')};
+  cursor: ${(props) => (props.$link ? 'pointer' : undefined)};
   text-align: center;
   height: ${(props) => props.size}px;
   width: ${(props) => props.size}px;

--- a/src/components/shared/styled.ts
+++ b/src/components/shared/styled.ts
@@ -538,7 +538,6 @@ export const StyledPanel = styled(Panel)<{ $maxWidth?: string }>`
   color: ${(props) => props.theme.colors.layout.page.color};
   border-radius: ${(props) => props.theme.other.panel.borderRadius};
   max-width: ${(props) => props.$maxWidth};
-  cursor: default;
   /* margin-bottom: 10px; */
 
   .rs-panel-heading {
@@ -641,12 +640,9 @@ export const StyledTagLink = styled(TagLink)`
 export const SecondaryTextWrapper = styled.span<{
   subtitle?: string;
   active?: boolean;
-  playing?: string;
 }>`
   color: ${(props) =>
-    props.playing === 'true'
-      ? props.theme.colors.primary
-      : props.subtitle === 'true'
+    props.subtitle === 'true'
       ? props.theme.colors.layout.page.colorSecondary
       : props.theme.colors.layout.page.color};
 `;

--- a/src/components/viewtypes/ListViewType.tsx
+++ b/src/components/viewtypes/ListViewType.tsx
@@ -180,7 +180,6 @@ const ListViewType = (
         style={{
           flexGrow: 1,
           height: '100%',
-          cursor: isDragging ? 'all-scroll' : 'default',
         }}
         ref={wrapperRef}
         onMouseDown={(e) => {

--- a/src/components/viewtypes/TableCells/CoverArtCell.tsx
+++ b/src/components/viewtypes/TableCells/CoverArtCell.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { LazyLoadImage } from 'react-lazy-load-image-component';
+import { isCached } from '../../../shared/utils';
+import { CoverArtWrapper } from '../../layout/styled';
+import { TableCellWrapper } from '../styled';
+
+const CoverArtCell = ({
+  rowData,
+  rowIndex,
+  column,
+  misc,
+  rowHeight,
+  cacheImages,
+  handleRowClick,
+  handleRowDoubleClick,
+  onMouseDown,
+  onMouseEnter,
+  onMouseUp,
+}: any) => {
+  return (
+    <TableCellWrapper
+      height={rowHeight}
+      onMouseDown={onMouseDown}
+      onMouseEnter={onMouseEnter}
+      onMouseUp={onMouseUp}
+      onClick={(e: any) => {
+        if (!column.dataKey?.match(/starred|userRating|genre|columnResizable|columnDefaultSort/)) {
+          handleRowClick(e, {
+            ...rowData,
+            rowIndex,
+          });
+        }
+      }}
+      onDoubleClick={() => {
+        if (!column.dataKey?.match(/starred|userRating|genre|columnResizable|columnDefaultSort/)) {
+          handleRowDoubleClick({
+            ...rowData,
+            rowIndex,
+          });
+        }
+      }}
+    >
+      <CoverArtWrapper size={rowHeight - 10}>
+        <LazyLoadImage
+          src={
+            isCached(
+              `${misc.imageCachePath}${cacheImages.cacheType}_${
+                rowData[cacheImages.cacheIdProperty]
+              }.jpg`
+            )
+              ? `${misc.imageCachePath}${cacheImages.cacheType}_${
+                  rowData[cacheImages.cacheIdProperty]
+                }.jpg`
+              : rowData.image
+          }
+          alt="track-img"
+          effect="opacity"
+          width={rowHeight - 10}
+          height={rowHeight - 10}
+          visibleByDefault
+        />
+      </CoverArtWrapper>
+    </TableCellWrapper>
+  );
+};
+
+export default CoverArtCell;

--- a/src/components/viewtypes/TableCells/CustomCell.tsx
+++ b/src/components/viewtypes/TableCells/CustomCell.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { TableCellWrapper } from '../styled';
+
+const CustomCell = ({
+  rowData,
+  rowIndex,
+  column,
+  rowHeight,
+  handleRowClick,
+  handleRowDoubleClick,
+  onMouseDown,
+  onMouseEnter,
+  onMouseUp,
+  nowPlaying,
+  sortColumn,
+  history,
+  children,
+  ...rest
+}: any) => {
+  return (
+    <TableCellWrapper
+      height={rowHeight}
+      onClick={(e: any) => {
+        if (!column.dataKey?.match(/starred|userRating|genre|columnResizable|columnDefaultSort/)) {
+          handleRowClick(e, {
+            ...rowData,
+            rowIndex,
+          });
+        }
+      }}
+      onDoubleClick={() => {
+        if (!column.dataKey?.match(/starred|userRating|genre|columnResizable|columnDefaultSort/)) {
+          handleRowDoubleClick({
+            ...rowData,
+            rowIndex,
+          });
+        }
+      }}
+      onMouseDown={onMouseDown}
+      onMouseEnter={onMouseEnter}
+      onMouseUp={onMouseUp}
+      {...rest}
+    >
+      {!children ? <span>&#8203;</span> : children}
+    </TableCellWrapper>
+  );
+};
+
+export default CustomCell;

--- a/src/components/viewtypes/TableCells/LinkCell.tsx
+++ b/src/components/viewtypes/TableCells/LinkCell.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { GenericItem } from '../../../types';
+import CustomTooltip from '../../shared/CustomTooltip';
+import { TableLinkButton, TableCellWrapper } from '../styled';
+
+const LinkCell = ({
+  linkProp,
+  onClickLink,
+  rowData,
+  rowIndex,
+  column,
+  rowHeight,
+  handleRowClick,
+  handleRowDoubleClick,
+  onMouseDown,
+  onMouseEnter,
+  onMouseUp,
+  nowPlaying,
+  sortColumn,
+  history,
+  fontSize,
+  ...rest
+}: any) => {
+  return (
+    <TableCellWrapper
+      height={rowHeight}
+      onClick={(e: any) => {
+        if (!column.dataKey?.match(/starred|userRating|genre|columnResizable|columnDefaultSort/)) {
+          handleRowClick(e, {
+            ...rowData,
+            rowIndex,
+          });
+        }
+      }}
+      onDoubleClick={() => {
+        if (!column.dataKey?.match(/starred|userRating|genre|columnResizable|columnDefaultSort/)) {
+          handleRowDoubleClick({
+            ...rowData,
+            rowIndex,
+          });
+        }
+      }}
+      onMouseDown={onMouseDown}
+      onMouseEnter={onMouseEnter}
+      onMouseUp={onMouseUp}
+      {...rest}
+    >
+      {linkProp === 'genre' && rowData.genre?.length === 0 ? (
+        <span>&#8203;</span>
+      ) : Array.isArray(rowData[linkProp]) ? (
+        rowData[linkProp].map((link: GenericItem, i: number) => (
+          <span key={`${rowData.uniqueId}-${link.id}`}>
+            {i > 0 && ', '}
+            <CustomTooltip text={link.title}>
+              <TableLinkButton
+                font={`${fontSize}px`}
+                onClick={(e: MouseEvent) => onClickLink(e, i)}
+              >
+                {link.title}
+              </TableLinkButton>
+            </CustomTooltip>
+          </span>
+        ))
+      ) : rowData[linkProp] ? (
+        <CustomTooltip text={rowData[linkProp]}>
+          <TableLinkButton font={`${fontSize}px`} onClick={onClickLink}>
+            {rowData[linkProp]}
+          </TableLinkButton>
+        </CustomTooltip>
+      ) : (
+        <span>&#8203;</span>
+      )}
+    </TableCellWrapper>
+  );
+};
+
+export default LinkCell;

--- a/src/components/viewtypes/TableCells/TextCell.tsx
+++ b/src/components/viewtypes/TableCells/TextCell.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { TableCellWrapper } from '../styled';
+
+const TextCell = ({
+  rowData,
+  rowIndex,
+  column,
+  rowHeight,
+  handleRowClick,
+  handleRowDoubleClick,
+  onMouseDown,
+  onMouseEnter,
+  onMouseUp,
+  ...rest
+}: any) => {
+  return (
+    <TableCellWrapper
+      height={rowHeight}
+      onClick={(e: any) => {
+        if (!column.dataKey?.match(/starred|userRating|genre|columnResizable|columnDefaultSort/)) {
+          handleRowClick(e, {
+            ...rowData,
+            rowIndex,
+          });
+        }
+      }}
+      onDoubleClick={() => {
+        if (!column.dataKey?.match(/starred|userRating|genre|columnResizable|columnDefaultSort/)) {
+          handleRowDoubleClick({
+            ...rowData,
+            rowIndex,
+          });
+        }
+      }}
+      onMouseDown={onMouseDown}
+      onMouseEnter={onMouseEnter}
+      onMouseUp={onMouseUp}
+      {...rest}
+    >
+      {rowData[column.dataKey] ? rowData[column.dataKey] : <span>&#8203;</span>}
+    </TableCellWrapper>
+  );
+};
+
+export default TextCell;

--- a/src/components/viewtypes/styled.tsx
+++ b/src/components/viewtypes/styled.tsx
@@ -1,10 +1,12 @@
 import styled from 'styled-components';
 import { Button, Table } from 'rsuite';
 
-export const RsuiteLinkButton = styled(Button)<{
+export const TableLinkButton = styled(Button)<{
   subtitle?: string;
   active?: boolean;
+  fontsize?: string;
 }>`
+  font-size: ${(props) => props.fontsize};
   background: transparent;
   max-width: 100%;
   padding: 0px;
@@ -12,42 +14,83 @@ export const RsuiteLinkButton = styled(Button)<{
   text-overflow: ellipsis;
   overflow: hidden;
   color: ${(props) =>
-    props.playing === 'true'
-      ? props.theme.colors.primary
-      : props.subtitle === 'true'
+    props.subtitle === 'true'
       ? props.theme.colors.layout.page.colorSecondary
       : props.theme.colors.layout.page.color};
 
   &:hover,
   &:active,
   &:focus {
-    background: transparent !important;
-    text-decoration: underline;
     color: ${(props) =>
-      props.playing === 'true'
-        ? props.theme.colors.primary
-        : props.subtitle === 'true'
+      props.subtitle === 'true'
         ? props.theme.colors.layout.page.colorSecondary
         : props.theme.colors.layout.page.color} !important;
+    background: transparent !important;
+    text-decoration: underline;
     cursor: pointer;
   }
 `;
 
 export const TableCellWrapper = styled.div<{
-  playing?: string;
   height?: number;
-  dragover?: string;
-  dragfield?: string;
 }>`
-  color: ${(props) => (props.playing === 'true' ? props.theme.colors.primary : undefined)};
+  margin-right: 5px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
   line-height: ${(props) => (props.height ? `${props.height}px` : undefined)};
-  cursor: ${(props) =>
-    props.dragover === 'true' ? 'grabbing' : props.dragfield === 'true' ? 'grab' : 'default'};
 `;
 
-export const CombinedTitleTextWrapper = styled.span<{ playing: string }>`
-  color: ${(props) => (props.playing === 'true' ? props.theme.colors.primary : undefined)};
+export const CombinedTitleContainer = styled.div<{ height: number }>`
+  .row-main {
+    height: ${(props) => props.height}px;
+    display: flex;
+    align-items: center;
 
+    .col-cover {
+      padding-right: 5px;
+      width: ${(props) => props.height}px;
+    }
+
+    .col-text {
+      width: 100%;
+      overflow: hidden;
+      padding-left: 10px;
+      padding-right: 20px;
+
+      .row-sub-text {
+        height: ${(props) => props.height / 2}px;
+        overflow: hidden;
+        position: relative;
+
+        .span {
+          position: absolute;
+          top: 0;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          overflow: hidden;
+          width: 100%;
+        }
+      }
+
+      .row-sub-secondarytext {
+        height: ${(props) => props.height / 2}px;
+        font-size: smaller;
+        overflow: hidden;
+        position: relative;
+        width: 100%;
+      }
+    }
+  }
+`;
+
+export const CombinedTitleTextWrapper = styled.span`
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
   &:focus-visible {
     outline: none;
     text-decoration: underline;

--- a/src/redux/multiSelectSlice.ts
+++ b/src/redux/multiSelectSlice.ts
@@ -96,6 +96,22 @@ const multiSelectSlice = createSlice({
       state.lastRangeSelected.lastRangeSelected = action.payload;
     },
 
+    toggleSelectedSingle: (state, action: PayloadAction<any>) => {
+      if (action.payload.uniqueId === state.selected[0]?.uniqueId) {
+        state.selected = [];
+      } else {
+        state.selected = [];
+        state.lastSelected = {};
+        state.lastRangeSelected = {
+          lastSelected: {},
+          lastRangeSelected: {},
+        };
+
+        state.lastSelected = action.payload;
+        state.selected.push(action.payload);
+      }
+    },
+
     toggleSelected: (state, action: PayloadAction<any>) => {
       if (state.selected.find((item) => item.uniqueId === action.payload.uniqueId)) {
         const indexOfItem = state.selected.findIndex(
@@ -143,6 +159,7 @@ export const {
   appendSelected,
   setRangeSelected,
   toggleSelected,
+  toggleSelectedSingle,
   toggleRangeSelected,
   clearSelected,
   setCurrentMouseOverId,


### PR DESCRIPTION
List-view was poorly optimized due to the multi-select drag implementation.

- Clean up component
  - Organize and split custom cell logic
  - Improve multi-select dragging
    - Crosshair cursor while multi-select dragging
    - Grabbing cursor persists while drag/dropping rows
  - Prevent excessive re-rendering (from 20+ renders per click to 1-3 on non-virtualized table)

This will greatly improve performance when creating list-views with non-virtualized `autoHeight`.