### PR TITLE
Add system notifications on song change

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -133,6 +133,9 @@ const configState: ConfigPage = {
     filters: [],
   },
   sort: {},
+  player: {
+    systemNotifications: false,
+  },
   serverType: Server.Subsonic,
   lookAndFeel: {
     font: 'Poppins',

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -26,7 +26,7 @@ import {
 import cacheSong from '../shared/cacheSong';
 import { isCached, isLinux } from '../../shared/utils';
 import { apiController } from '../../api/controller';
-import { Server } from '../../types';
+import { Artist, Server } from '../../types';
 import { setStatus } from '../../redux/playerSlice';
 
 const gaplessListenHandler = (
@@ -512,21 +512,29 @@ const Player = ({ currentEntryList, muted, children }: any, ref: any) => {
           dispatch(setIsFading(false));
         }
 
-        ipcRenderer.send(
-          'current-song',
+        const nextSong =
           playQueue[currentEntryList][
             getNextPlayerIndex(
               playQueue[currentEntryList].length,
               playQueue.repeat,
               playQueue.player1.index
             )
-          ]
-        );
+          ];
+
+        if (config.player.systemNotifications) {
+          // eslint-disable-next-line no-new
+          new Notification(nextSong.title, {
+            body: `${nextSong.artist.map((artist: Artist) => artist.title).join(', ')}\n${
+              nextSong.album
+            }`,
+            icon: nextSong.image,
+          });
+        }
 
         dispatch(setAutoIncremented(false));
       }
     }
-  }, [cacheSongs, currentEntryList, dispatch, playQueue]);
+  }, [cacheSongs, config.player.systemNotifications, currentEntryList, dispatch, playQueue]);
 
   const handleOnEndedPlayer2 = useCallback(() => {
     player2Ref.current.audioEl.current.currentTime = 0;
@@ -567,21 +575,30 @@ const Player = ({ currentEntryList, muted, children }: any, ref: any) => {
           dispatch(setIsFading(false));
         }
 
-        ipcRenderer.send(
-          'current-song',
+        const nextSong =
           playQueue[currentEntryList][
             getNextPlayerIndex(
               playQueue[currentEntryList].length,
               playQueue.repeat,
               playQueue.player2.index
             )
-          ]
-        );
+          ];
+        ipcRenderer.send('current-song', nextSong);
+
+        if (config.player.systemNotifications) {
+          // eslint-disable-next-line no-new
+          new Notification(nextSong.title, {
+            body: `${nextSong.artist.map((artist: Artist) => artist.title).join(', ')}\n${
+              nextSong.album
+            }`,
+            icon: nextSong.image,
+          });
+        }
 
         dispatch(setAutoIncremented(false));
       }
     }
-  }, [cacheSongs, currentEntryList, dispatch, playQueue]);
+  }, [cacheSongs, config.player.systemNotifications, currentEntryList, dispatch, playQueue]);
 
   const handleGaplessPlayer1 = useCallback(() => {
     gaplessListenHandler(

--- a/src/components/settings/ConfigPanels/PlayerConfig.tsx
+++ b/src/components/settings/ConfigPanels/PlayerConfig.tsx
@@ -20,7 +20,7 @@ import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
 import i18n from '../../../i18n/i18n';
 import { setPlaybackSetting } from '../../../redux/playQueueSlice';
 import ListViewTable from '../../viewtypes/ListViewTable';
-import { appendPlaybackFilter, setAudioDeviceId } from '../../../redux/configSlice';
+import { appendPlaybackFilter, setAudioDeviceId, setPlayer } from '../../../redux/configSlice';
 import { notifyToast } from '../../shared/toast';
 import ConfigOption from '../ConfigOption';
 import { Server } from '../../../types';
@@ -278,6 +278,21 @@ const PlayerConfig = ({ bordered }: any) => {
           }
         />
       )}
+
+      <ConfigOption
+        name={t('System Notifications')}
+        description={<>{t('Show a system notification whenever the song changes.')}</>}
+        option={
+          <StyledToggle
+            defaultChecked={config.player.systemNotifications}
+            checked={config.player.systemNotifications}
+            onChange={(e: boolean) => {
+              settings.setSync('systemNotifications', e);
+              dispatch(setPlayer({ systemNotifications: e }));
+            }}
+          />
+        }
+      />
 
       <ConfigOption
         name={t('Scrobble')}

--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -111,6 +111,10 @@ const setDefaultSettings = (force: boolean) => {
     settings.setSync('scrobble', false);
   }
 
+  if (force || !settings.hasSync('systemNotifications')) {
+    settings.setSync('systemNotifications', false);
+  }
+
   if (force || !settings.hasSync('musicFolder.id')) {
     settings.setSync('musicFolder.id', null);
   }

--- a/src/main.dev.js
+++ b/src/main.dev.js
@@ -541,6 +541,8 @@ const createWindow = async () => {
   });
 
   if (isWindows()) {
+    app.setAppUserModelId(process.execPath);
+
     mainWindow.on('resize', () => {
       const window = mainWindow.getContentBounds();
 

--- a/src/redux/configSlice.ts
+++ b/src/redux/configSlice.ts
@@ -28,6 +28,9 @@ export interface ConfigPage {
     genreListPage?: SortColumn;
     playlistListPage?: SortColumn;
   };
+  player: {
+    systemNotifications: boolean;
+  };
   lookAndFeel: {
     font: string;
     listView: {
@@ -105,6 +108,9 @@ const initialState: ConfigPage = {
   playback: {
     filters: parsedSettings.playbackFilters,
     audioDeviceId: parsedSettings.audioDeviceId || undefined,
+  },
+  player: {
+    systemNotifications: parsedSettings.systemNotifications,
   },
   sort: {
     albumListPage: undefined,
@@ -219,6 +225,13 @@ const configSlice = createSlice({
     setSidebar: (state, action: PayloadAction<any>) => {
       state.lookAndFeel.sidebar = {
         ...state.lookAndFeel.sidebar,
+        ...action.payload,
+      };
+    },
+
+    setPlayer: (state, action: PayloadAction<any>) => {
+      state.player = {
+        ...state.player,
         ...action.payload,
       };
     },
@@ -354,5 +367,6 @@ export const {
   setOBS,
   setSidebar,
   setWindow,
+  setPlayer,
 } = configSlice.actions;
 export default configSlice.reducer;

--- a/src/shared/mockSettings.ts
+++ b/src/shared/mockSettings.ts
@@ -22,6 +22,7 @@ export const mockSettings = {
   pollingInterval: 20,
   fadeDuration: 9,
   fadeType: 'equalPower',
+  systemNotifications: false,
   scrobble: false,
   transcode: false,
   sidebar: {


### PR DESCRIPTION
Closes #245

Adds a native system notification when the song automatically changes using the HTML5 notification API.
The notification includes the following data (tested on Windows / Ubuntu):
- Song/Album art
- Song title
- Song artists
- Album name

Added setting under `Player` settings
![image](https://user-images.githubusercontent.com/42182408/157655640-d05b0eca-abff-48ce-8ef1-e751310de9d7.png)
