### PR TITLE
MacOS exit to tray

### DIFF
--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -1,6 +1,7 @@
 import settings from 'electron-settings';
 import path from 'path';
 import i18n from '../../i18n/i18n';
+import { isMacOS } from '../../shared/utils';
 
 const setDefaultSettings = (force: boolean) => {
   if (force || !settings.hasSync('discord.enabled')) {
@@ -76,7 +77,11 @@ const setDefaultSettings = (force: boolean) => {
   }
 
   if (force || !settings.hasSync('exitToTray')) {
-    settings.setSync('exitToTray', false);
+    let defaultExitToTray = false;
+    if(isMacOS()) {
+      defaultExitToTray = true;
+    }
+    settings.setSync('exitToTray', defaultExitToTray);
   }
 
   if (force || !settings.hasSync('showDebugWindow')) {

--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -78,7 +78,7 @@ const setDefaultSettings = (force: boolean) => {
 
   if (force || !settings.hasSync('exitToTray')) {
     let defaultExitToTray = false;
-    if(isMacOS()) {
+    if (isMacOS()) {
       defaultExitToTray = true;
     }
     settings.setSync('exitToTray', defaultExitToTray);

--- a/src/main.dev.js
+++ b/src/main.dev.js
@@ -49,6 +49,7 @@ replayActionMain(store);
 let mainWindow = null;
 let tray = null;
 let exitFromTray = false;
+let forceQuit = false;
 
 if (process.env.NODE_ENV === 'production') {
   const sourceMapSupport = require('source-map-support');
@@ -538,6 +539,9 @@ const createWindow = async () => {
       event.preventDefault();
       mainWindow.hide();
     }
+    if (forceQuit) {
+      app.exit();
+    }
   });
 
   if (isWindows()) {
@@ -585,6 +589,10 @@ const createWindow = async () => {
         width: window.width,
         height: window.height,
       });
+    });
+
+    app.on('before-quit', function() {
+      forceQuit = true;
     });
   }
 

--- a/src/main.dev.js
+++ b/src/main.dev.js
@@ -591,7 +591,7 @@ const createWindow = async () => {
       });
     });
 
-    app.on('before-quit', function() {
+    app.on('before-quit', () => {
       forceQuit = true;
     });
   }

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -68,7 +68,7 @@ export default class MenuBuilder {
           label: 'Quit',
           accelerator: 'Command+Q',
           click: () => {
-            app.quit();
+            app.exit();
           },
         },
       ],


### PR DESCRIPTION
This MR aims to provide a more native/intuitive behaviour in MacOS.

- Enables 'exit to tray' by default in MacOS so music can continue in the background.
- Fixes the 'Quit' menu bar item so that the app can be fully quit when in 'exit to tray' mode.
- Fixes the app badge 'Quit' item so app can be fully quit from badge in 'exit to tray' mode.

Demonstration of fix: all settings set to default, app running in tray, opening and closing from system menus:

https://user-images.githubusercontent.com/2040617/158901419-834363ea-74cf-46d8-8d29-eb5b25b71d9a.mov

Closes https://github.com/jeffvli/sonixd/issues/264
