### PR TITLE
Default titlebar for macos

### DIFF
--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -98,7 +98,7 @@ const setDefaultSettings = (force: boolean) => {
 
   if (force || !settings.hasSync('titleBarStyle')) {
     let defaultTitleBarStyle = 'windows';
-    if(isMacOS()) {
+    if (isMacOS()) {
       defaultTitleBarStyle = 'mac';
     }
     settings.setSync('titleBarStyle', defaultTitleBarStyle);

--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -1,6 +1,7 @@
 import settings from 'electron-settings';
 import path from 'path';
 import i18n from '../../i18n/i18n';
+import { isMacOS } from '../../shared/utils';
 
 const setDefaultSettings = (force: boolean) => {
   if (force || !settings.hasSync('discord.enabled')) {
@@ -96,7 +97,11 @@ const setDefaultSettings = (force: boolean) => {
   }
 
   if (force || !settings.hasSync('titleBarStyle')) {
-    settings.setSync('titleBarStyle', 'windows');
+    let defaultTitleBarStyle = 'windows';
+    if(isMacOS()) {
+      defaultTitleBarStyle = 'mac';
+    }
+    settings.setSync('titleBarStyle', defaultTitleBarStyle);
   }
 
   if (force || !settings.hasSync('artistPageLegacy')) {


### PR DESCRIPTION
Sets the default title bar to the native one for MacOS.

Mac apps titlebars have 'close','minimise' ect on the left side unlike on windows. This PR aims to give a more native feel.

![Screenshot 2022-03-17 at 22 09 14](https://user-images.githubusercontent.com/2040617/158902959-b803c02e-f76d-4a68-854b-a71232f77706.png)

