### PR TITLE
Fix hot reload on windows

### DIFF
--- a/.erb/configs/webpack.config.renderer.dev.babel.js
+++ b/.erb/configs/webpack.config.renderer.dev.babel.js
@@ -245,6 +245,7 @@ export default merge(baseConfig, {
   devServer: {
     port,
     hot: true,
+    host: "127.0.0.1",
     headers: { 'Access-Control-Allow-Origin': '*' },
     historyApiFallback: {
       verbose: true,


### PR DESCRIPTION
From #288, fixes webpack dev server hot reload. For some reason on Windows, 0.0.0.0 does not resolve to localhost, so we force it to use 127.0.0.1.