### PR TITLE
Discord rich presence enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "@teamsupercell/typings-for-css-modules-loader": "^2.4.0",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
+    "@types/discord-rpc": "^4.0.2",
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/history": "4.7.6",

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -403,6 +403,7 @@ const configState: ConfigPage = {
     discord: {
       enabled: false,
       clientId: '',
+      serverImage: false,
     },
     obs: {
       enabled: false,

--- a/src/components/settings/ConfigPanels/ExternalConfig.tsx
+++ b/src/components/settings/ConfigPanels/ExternalConfig.tsx
@@ -16,6 +16,7 @@ import {
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
 import { setDiscord, setOBS } from '../../../redux/configSlice';
 import ConfigOption from '../ConfigOption';
+import { Server } from '../../../types';
 
 const dialog: any = process.env.NODE_ENV === 'test' ? '' : require('electron').remote.dialog;
 
@@ -73,6 +74,27 @@ const ExternalConfig = ({ bordered }: any) => {
             />
           }
         />
+        {config.serverType === Server.Jellyfin && (
+          <ConfigOption
+            name={t('Display Song Images')}
+            description={
+              <Trans t={t}>
+                Uses the song image returned by your server (only works if your server is publically
+                accessible).
+              </Trans>
+            }
+            option={
+              <StyledToggle
+                defaultChecked={config.external.discord.serverImage}
+                checked={config.external.discord.serverImage}
+                onChange={(e: boolean) => {
+                  settings.setSync('discord.serverImage', e);
+                  dispatch(setDiscord({ ...config.external.discord, serverImage: e }));
+                }}
+              />
+            }
+          />
+        )}
       </ConfigPanel>
       <ConfigPanel header="OBS (Open Broadcaster Software)" collapsible $noBackground>
         <ConfigOption

--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -12,6 +12,10 @@ const setDefaultSettings = (force: boolean) => {
     settings.setSync('discord.clientId', '923372440934055968');
   }
 
+  if (force || !settings.hasSync('discord.serverImage')) {
+    settings.setSync('discord.serverImage', false);
+  }
+
   if (force || !settings.hasSync('obs.enabled')) {
     settings.setSync('obs.enabled', false);
   }

--- a/src/hooks/useDiscordRpc.ts
+++ b/src/hooks/useDiscordRpc.ts
@@ -1,0 +1,110 @@
+/* eslint-disable consistent-return */
+import { useEffect, useState } from 'react';
+import RPC, { Presence } from 'discord-rpc';
+import { notifyToast } from '../components/shared/toast';
+import { useAppSelector } from '../redux/hooks';
+import { Artist, Server } from '../types';
+
+const useDiscordRpc = ({ playersRef }: any) => {
+  const player = useAppSelector((state) => state.player);
+  const playQueue = useAppSelector((state) => state.playQueue);
+  const config = useAppSelector((state) => state.config);
+  const [discordRpc, setDiscordRpc] = useState<any>();
+
+  useEffect(() => {
+    if (config.external.discord.enabled && config.external.discord.clientId.length === 18) {
+      const client = new RPC.Client({ transport: 'ipc' });
+
+      if (discordRpc?.client !== config.external.discord.clientId) {
+        client.login({ clientId: config.external.discord.clientId }).catch((err: any) => {
+          notifyToast('error', `${err}`);
+        });
+
+        client.once('connected', () => {
+          notifyToast('success', 'Discord RPC is connected');
+        });
+
+        setDiscordRpc(client);
+      }
+    }
+  }, [config.external.discord.clientId, config.external.discord.enabled, discordRpc?.client]);
+
+  useEffect(() => {
+    if (!config.external.discord.enabled) {
+      try {
+        discordRpc?.destroy();
+      } catch (err) {
+        notifyToast('error', `${err}`);
+      }
+    }
+  }, [config.external.discord.enabled, discordRpc]);
+
+  useEffect(() => {
+    if (config.external.discord.enabled) {
+      const setActivity = async () => {
+        if (!discordRpc) {
+          return;
+        }
+
+        const currentPlayer =
+          playQueue.currentPlayer === 1
+            ? playersRef.current?.player1.audioEl.current
+            : playersRef.current?.player2.audioEl.current;
+
+        const now = Date.now();
+        const start = Math.round(now - currentPlayer.currentTime * 1000) || 0;
+        const end = Math.round(start + playQueue?.current?.duration * 1000) || 0;
+
+        const artists = playQueue.current?.artist.map((artist: Artist) => artist.title).join(', ');
+
+        const activity: Presence = {
+          details: playQueue.current?.title.padEnd(2, ' ') || 'Not playing',
+          state: artists && `By ${artists}`,
+          largeImageKey: undefined,
+          largeImageText: playQueue.current?.album || 'Unknown album',
+          smallImageKey: undefined,
+          smallImageText: player.status,
+          instance: false,
+        };
+
+        if (player.status === 'PLAYING') {
+          activity.startTimestamp = start;
+          activity.endTimestamp = end;
+          activity.smallImageKey = 'playing';
+        } else {
+          activity.smallImageKey = 'paused';
+        }
+
+        if (config.serverType === Server.Jellyfin && config.external.discord.serverImage) {
+          activity.largeImageKey = playQueue.current?.image;
+        }
+
+        // Fall back to default icon if not set
+        if (!activity.largeImageKey) {
+          activity.largeImageKey = 'icon';
+        }
+
+        discordRpc.setActivity(activity);
+      };
+
+      // Activity can only be set every 15 seconds
+      const interval = setInterval(() => {
+        setActivity();
+      }, 15e3);
+
+      return () => clearInterval(interval);
+    }
+    return () => clearInterval();
+  }, [
+    config.external.discord.enabled,
+    config.external.discord.serverImage,
+    config.serverType,
+    discordRpc,
+    playQueue,
+    playQueue.currentPlayer,
+    player.status,
+    playersRef,
+  ]);
+};
+
+export default useDiscordRpc;

--- a/src/redux/configSlice.ts
+++ b/src/redux/configSlice.ts
@@ -52,6 +52,7 @@ export interface ConfigPage {
     discord: {
       enabled: boolean;
       clientId: string;
+      serverImage: boolean;
     };
     obs: {
       enabled: boolean;
@@ -198,6 +199,7 @@ const initialState: ConfigPage = {
     discord: {
       enabled: parsedSettings.discord?.enabled || false,
       clientId: parsedSettings.discord?.clientId || '',
+      serverImage: parsedSettings.discord?.serverImage || false,
     },
     obs: {
       enabled: parsedSettings.obs?.enabled || false,

--- a/src/shared/mockSettings.ts
+++ b/src/shared/mockSettings.ts
@@ -343,6 +343,7 @@ export const mockSettings = {
     enabled: true,
     applicationId: '',
     clientId: '923372440934055968',
+    serverImage: false,
   },
   obs: {
     enabled: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1749,6 +1749,11 @@
   dependencies:
     "@types/ms" "*"
 
+"@types/discord-rpc@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/discord-rpc/-/discord-rpc-4.0.2.tgz#5eae11545ebb9046e686ab5b438db6f7cb7ca8e8"
+  integrity sha512-0cmpmTvq4vR6UrYDV4Lb+D/NySNYAvCmRvKSN6YUwy+Jy7gTZ+dQpGG2E2kT8dqE8SwMDGWyLp71c0C5qRbtXA==
+
 "@types/enzyme-adapter-react-16@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.6.tgz#8aca7ae2fd6c7137d869b6616e696d21bb8b0cec"


### PR DESCRIPTION
Closes #286 

- Adds small rpc image for playback status
  - uses `playing` and `paused` image keys
- Adds start/stop timestamp for song
- (Jellyfin) Adds config to use song/album cover url for the rich presence image. Not enabled for subsonic due to auth requirement to view image