### PR TITLE
Add SCOOP installation method for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,16 @@ You can install sonixd by downloading the [latest release](https://github.com/je
 
 ### Windows
 
-If you prefer not to download the release binary, you can install using `winget`.
-
-Using your favorite terminal (cmd/pwsh):
+If you prefer not to download the release binary, you can install using `winget`. Using your favorite terminal (cmd/pwsh):
 
 ```
 winget install sonixd
+```
+
+Or you can install using [scoop](https://scoop.sh).
+
+```
+scoop install sonixd
 ```
 
 ---


### PR DESCRIPTION
I have already pr to repo of SCOOP, see https://github.com/scoopinstaller/extras/pull/8395. Now everyone can use scoop for installation.