### PR TITLE
Fix homebrew cask name

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ scoop install sonixd
 If you prefer not to download the release binary, you can install using `homebrew`. Using your favorite terminal:
 
 ```
-brew install --cask sonicxd
+brew install --cask sonixd
 ```
 
 ---


### PR DESCRIPTION
I found a small spelling error on the README for the name of the homebrew cask: `sonicxd` -> `sonixd`. 