### PR TITLE
change dependency for macos m1 build

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "detect-port": "^1.3.0",
     "electron": "13.6.3",
     "electron-builder": "23.0.2",
-    "electron-devtools-installer": "git+https://github.com/MarshallOfSound/electron-devtools-installer.git",
+    "electron-devtools-installer": "3.2.0",
     "electron-notarize": "^1.0.0",
     "electron-rebuild": "2.3.5",
     "enzyme": "^3.11.0",


### PR DESCRIPTION
I ran into "package damaged" when trying to install from brew or github releases, with this package json i can build and it runs.