### PR TITLE
Make cover art images non-selectable

### DIFF
--- a/src/styles/App.global.css
+++ b/src/styles/App.global.css
@@ -58,6 +58,7 @@ body {
 .rs-panel-body,
 .rs-panel-heading {
   padding: 0px;
+  user-select: none;
 }
 
 .rs-popover.in {


### PR DESCRIPTION
Right now you can select the album covers on the dashboard or the album view. This pr will fix the issue by making them non-selectable.

I did not found any issues with UI elements so far.

![Dashboard](https://share.pauli.gg/2022-06-29_22.56.12_7a4271_Sonixd.png)

![Detail view](https://share.pauli.gg/2022-06-29_22.54.41_823dfa_Sonixd.png)