### PR TITLE
Add KDE Breeze Dark theme

### DIFF
--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -1902,6 +1902,170 @@ const setDefaultSettings = (force: boolean) => {
         },
       },
     },
+    {
+      label: 'Breeze Dark',
+      value: 'breezeDark',
+      type: 'dark',
+      fonts: {
+        size: {
+          page: '14px',
+          panelTitle: '20px'
+        }
+      },
+      colors: {
+        primary: '#3DAEE9',
+        layout: {
+          page: {
+            color: '#FCFDFC',
+            colorSecondary: '#A1A9B1',
+            background: '#1B1E20'
+          },
+          playerBar: {
+            color: '#FCFDFC',
+            colorSecondary: '#FCFDFC',
+            background: '#1B1E20',
+            button: {
+              color: 'rgba(240, 240, 240, 0.8)',
+              colorHover: '#3DAEE9'
+            }
+          },
+          sideBar: {
+            background: '#2A2E32',
+            button: {
+              color: '#FCFCFC',
+              colorHover: '#3DAEE9'
+            }
+          },
+          titleBar: {
+            color: '#31363B',
+            background: '#FCFCFC'
+          },
+          miniPlayer: {
+            background: '#1B1E20'
+          }
+        },
+        button: {
+          default: {
+            color: '#FCFCFC',
+            colorHover: '#FFFFFF',
+            background: '#31363B',
+            backgroundHover: '#334E5E'
+          },
+          primary: {
+            color: '#FCFCFC',
+            colorHover: '#FFFFFF',
+            backgroundHover: '#3DAEE9'
+          },
+          subtle: {
+            color: '#FCFDFC',
+            colorHover: '#FCFDFC',
+            backgroundHover: 'transparent'
+          },
+          link: {
+            color: '#3DAEE9',
+            colorHover: '#9B59B6'
+          }
+        },
+        card: {
+          overlayButton: {
+            color: '#FFFFFF',
+            background: 'transparent',
+            opacity: 0.8
+          }
+        },
+        contextMenu: {
+          color: '#FCFCFC',
+          colorDisabled: '#A1A9B1',
+          background: '#2A2E32',
+          backgroundHover: '#2D5165'
+        },
+        input: {
+          color: '#D8D8D8',
+          background: '#212227',
+          backgroundHover: '#2D5165',
+          backgroundActive: 'rgba(240, 240, 240, .2)'
+        },
+        nav: {
+          color: '#FCFCFC'
+        },
+        popover: {
+          color: '#FCFCFC',
+          background: '#151619'
+        },
+        slider: {
+          background: '#2A2E32',
+          progressBar: '#3DAEE9'
+        },
+        spinner: {
+          background: 'rgba(233, 235, 240, 0.3)',
+          foreground: '#3DAEE9'
+        },
+        table: {
+          selectedRow: '#1E5774'
+        },
+        tag: {
+          background: '#31363B',
+          text: '#FCFCFC'
+        },
+        tooltip: {
+          color: '#FCFCFC',
+          background: '#31363B'
+        }
+      },
+      other: {
+        button: {
+          borderRadius: '15px'
+        },
+        coverArtBorderRadius: '5px',
+        coverArtFilter: 'none',
+        card: {
+          border: 'none',
+          hover: {
+            transform: 'none',
+            transition: 'none',
+            filter: 'none'
+          },
+          image: {
+            borderTop: '2px transparent ridge',
+            borderRight: '2px transparent ridge',
+            borderBottom: '2px transparent ridge',
+            borderLeft: '2px transparent ridge',
+            borderRadius: '15px'
+          },
+          info: {
+            borderTop: 'none',
+            borderRight: 'none',
+            borderBottom: 'none',
+            borderLeft: 'none',
+            borderRadius: '0px'
+          }
+        },
+        input: {
+          borderRadius: '15px'
+        },
+        miniPlayer: {
+          height: '450px',
+          opacity: 0.95
+        },
+        panel: {
+          borderRadius: '0px'
+        },
+        playerBar: {
+          borderTop: '1px solid rgba(240, 240, 240, .15)',
+          borderRight: 'none',
+          borderBottom: 'none',
+          borderLeft: 'none',
+          filter: 'none'
+        },
+        tag: {
+          borderRadius: '15px'
+        },
+        tooltip: {
+          border: '1px #3C3F43 solid',
+          borderRadius: '5px'
+        }
+      }
+    },
   ]);
 };
 

--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -1909,8 +1909,8 @@ const setDefaultSettings = (force: boolean) => {
       fonts: {
         size: {
           page: '14px',
-          panelTitle: '20px'
-        }
+          panelTitle: '20px',
+        },
       },
       colors: {
         primary: '#3DAEE9',
@@ -1918,7 +1918,7 @@ const setDefaultSettings = (force: boolean) => {
           page: {
             color: '#FCFDFC',
             colorSecondary: '#A1A9B1',
-            background: '#1B1E20'
+            background: '#1B1E20',
           },
           playerBar: {
             color: '#FCFDFC',
@@ -1926,95 +1926,95 @@ const setDefaultSettings = (force: boolean) => {
             background: '#1B1E20',
             button: {
               color: 'rgba(240, 240, 240, 0.8)',
-              colorHover: '#3DAEE9'
-            }
+              colorHover: '#3DAEE9',
+            },
           },
           sideBar: {
             background: '#2A2E32',
             button: {
               color: '#FCFCFC',
-              colorHover: '#3DAEE9'
-            }
+              colorHover: '#3DAEE9',
+            },
           },
           titleBar: {
             color: '#31363B',
-            background: '#FCFCFC'
+            background: '#FCFCFC',
           },
           miniPlayer: {
-            background: '#1B1E20'
-          }
+            background: '#1B1E20',
+          },
         },
         button: {
           default: {
             color: '#FCFCFC',
             colorHover: '#FFFFFF',
             background: '#31363B',
-            backgroundHover: '#334E5E'
+            backgroundHover: '#334E5E',
           },
           primary: {
             color: '#FCFCFC',
             colorHover: '#FFFFFF',
-            backgroundHover: '#3DAEE9'
+            backgroundHover: '#3DAEE9',
           },
           subtle: {
             color: '#FCFDFC',
             colorHover: '#FCFDFC',
-            backgroundHover: 'transparent'
+            backgroundHover: 'transparent',
           },
           link: {
             color: '#3DAEE9',
-            colorHover: '#9B59B6'
-          }
+            colorHover: '#9B59B6',
+          },
         },
         card: {
           overlayButton: {
             color: '#FFFFFF',
             background: 'transparent',
-            opacity: 0.8
-          }
+            opacity: 0.8,
+          },
         },
         contextMenu: {
           color: '#FCFCFC',
           colorDisabled: '#A1A9B1',
           background: '#2A2E32',
-          backgroundHover: '#2D5165'
+          backgroundHover: '#2D5165',
         },
         input: {
           color: '#D8D8D8',
           background: '#212227',
           backgroundHover: '#2D5165',
-          backgroundActive: 'rgba(240, 240, 240, .2)'
+          backgroundActive: 'rgba(240, 240, 240, .2)',
         },
         nav: {
-          color: '#FCFCFC'
+          color: '#FCFCFC',
         },
         popover: {
           color: '#FCFCFC',
-          background: '#151619'
+          background: '#151619',
         },
         slider: {
           background: '#2A2E32',
-          progressBar: '#3DAEE9'
+          progressBar: '#3DAEE9',
         },
         spinner: {
           background: 'rgba(233, 235, 240, 0.3)',
-          foreground: '#3DAEE9'
+          foreground: '#3DAEE9',
         },
         table: {
-          selectedRow: '#1E5774'
+          selectedRow: '#1E5774',
         },
         tag: {
           background: '#31363B',
-          text: '#FCFCFC'
+          text: '#FCFCFC',
         },
         tooltip: {
           color: '#FCFCFC',
-          background: '#31363B'
-        }
+          background: '#31363B',
+        },
       },
       other: {
         button: {
-          borderRadius: '15px'
+          borderRadius: '15px',
         },
         coverArtBorderRadius: '5px',
         coverArtFilter: 'none',
@@ -2023,48 +2023,48 @@ const setDefaultSettings = (force: boolean) => {
           hover: {
             transform: 'none',
             transition: 'none',
-            filter: 'none'
+            filter: 'none',
           },
           image: {
             borderTop: '2px transparent ridge',
             borderRight: '2px transparent ridge',
             borderBottom: '2px transparent ridge',
             borderLeft: '2px transparent ridge',
-            borderRadius: '15px'
+            borderRadius: '15px',
           },
           info: {
             borderTop: 'none',
             borderRight: 'none',
             borderBottom: 'none',
             borderLeft: 'none',
-            borderRadius: '0px'
-          }
+            borderRadius: '0px',
+          },
         },
         input: {
-          borderRadius: '15px'
+          borderRadius: '15px',
         },
         miniPlayer: {
           height: '450px',
-          opacity: 0.95
+          opacity: 0.95,
         },
         panel: {
-          borderRadius: '0px'
+          borderRadius: '0px',
         },
         playerBar: {
           borderTop: '1px solid rgba(240, 240, 240, .15)',
           borderRight: 'none',
           borderBottom: 'none',
           borderLeft: 'none',
-          filter: 'none'
+          filter: 'none',
         },
         tag: {
-          borderRadius: '15px'
+          borderRadius: '15px',
         },
         tooltip: {
           border: '1px #3C3F43 solid',
-          borderRadius: '5px'
-        }
-      }
+          borderRadius: '5px',
+        },
+      },
     },
   ]);
 };

--- a/src/components/shared/setDefaultSettings.ts
+++ b/src/components/shared/setDefaultSettings.ts
@@ -1937,8 +1937,8 @@ const setDefaultSettings = (force: boolean) => {
             },
           },
           titleBar: {
-            color: '#31363B',
-            background: '#FCFCFC',
+            color: '#FCFCFC',
+            background: '#31363B',
           },
           miniPlayer: {
             background: '#1B1E20',


### PR DESCRIPTION
This PR adds a new theme that follows the style from KDE's Breeze Dark.

<img width="1025" alt="breezeDark1" src="https://user-images.githubusercontent.com/43704682/178387668-ae903f36-074a-43e5-b282-83df003bf1e1.png">

<img width="980" alt="breezeDark2" src="https://user-images.githubusercontent.com/43704682/178387824-c176fd53-7d4b-4382-8902-2dc2bf082c18.png">

