### PR TITLE
Add Ctrl+Q keyboard short for Linux

### DIFF
--- a/src/main.dev.js
+++ b/src/main.dev.js
@@ -107,6 +107,11 @@ const previousTrack = () => {
 };
 
 if (isLinux()) {
+
+  electronLocalshortcut.register('Control+Q', () => {
+    app.exit();
+  });
+
   const mprisPlayer = Player({
     name: 'Sonixd',
     identity: 'Sonixd',

--- a/src/main.dev.js
+++ b/src/main.dev.js
@@ -107,7 +107,6 @@ const previousTrack = () => {
 };
 
 if (isLinux()) {
-
   electronLocalshortcut.register('Control+Q', () => {
     app.exit();
   });


### PR DESCRIPTION
KDE and GNOME both use Ctrl+Q as a keyboard shortcut to quit the application.  This patch adds that shortcut if Linux is detected as the OS.

