### PR TITLE
Fix now playing notifications being off by one

### DIFF
--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -615,15 +615,20 @@ const Player = ({ currentEntryList, muted, children }: any, ref: any) => {
 
   const handleOnPlay = useCallback(
     (playerNumber: 1 | 2) => {
+      const currentSong =
+        playerNumber === 1
+          ? playQueue[currentEntryList][playQueue.player1.index]
+          : playQueue[currentEntryList][playQueue.player2.index];
+
       ipcRenderer.send('current-song', playQueue.current);
 
-      if (config.player.systemNotifications) {
+      if (config.player.systemNotifications && currentSong) {
         // eslint-disable-next-line no-new
-        new Notification(playQueue.current.title, {
-          body: `${playQueue.current.artist.map((artist: Artist) => artist.title).join(', ')}\n${
-            playQueue.current.album
+        new Notification(currentSong.title, {
+          body: `${currentSong.artist.map((artist: Artist) => artist.title).join(', ')}\n${
+            currentSong.album
           }`,
-          icon: playQueue.current.image,
+          icon: currentSong.image,
         });
       }
 
@@ -637,10 +642,7 @@ const Player = ({ currentEntryList, muted, children }: any, ref: any) => {
           serverType: config.serverType,
           endpoint: 'scrobble',
           args: {
-            id:
-              playerNumber === 1
-                ? playQueue[currentEntryList][playQueue.player1.index]?.id
-                : playQueue[currentEntryList][playQueue.player2.index]?.id,
+            id: currentSong?.id,
             submission: false,
             position: currentSeek * 1e7,
             event: 'unpause',


### PR DESCRIPTION
This seeks to fix #362. Instead of using `playerQueue.current`, use the same logic for scrobbling.

I'm not sure whether the `current-song` event should also use currentSong or not? 