### PR TITLE
Remove hard limit on discord client id length

### DIFF
--- a/src/components/settings/ConfigPanels/ExternalConfig.tsx
+++ b/src/components/settings/ConfigPanels/ExternalConfig.tsx
@@ -40,7 +40,6 @@ const ExternalConfig = ({ bordered }: any) => {
             <StyledToggle
               defaultChecked={config.external.discord.enabled}
               checked={config.external.discord.enabled}
-              disabled={config.external.discord.clientId.length !== 18}
               onChange={(e: boolean) => {
                 settings.setSync('discord.enabled', e);
                 dispatch(setDiscord({ ...config.external.discord, enabled: e }));

--- a/src/hooks/useDiscordRpc.ts
+++ b/src/hooks/useDiscordRpc.ts
@@ -12,7 +12,7 @@ const useDiscordRpc = ({ playersRef }: any) => {
   const [discordRpc, setDiscordRpc] = useState<any>();
 
   useEffect(() => {
-    if (config.external.discord.enabled && config.external.discord.clientId.length === 18) {
+    if (config.external.discord.enabled) {
       const client = new RPC.Client({ transport: 'ipc' });
 
       if (discordRpc?.client !== config.external.discord.clientId) {
@@ -94,7 +94,7 @@ const useDiscordRpc = ({ playersRef }: any) => {
 
       return () => clearInterval(interval);
     }
-    return () => clearInterval();
+    return () => {};
   }, [
     config.external.discord.enabled,
     config.external.discord.serverImage,


### PR DESCRIPTION
Discord RPC clientid length used to be hard-coded to a length of 18.

This PR removes the hard limit and allows any number of digits.