### PR TITLE
Encode subsonic plaintext passwords when using them in api calls

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -15,6 +15,7 @@ const getAuth = (useLegacyAuth: boolean) => {
     return {
       username: localStorage.getItem('username') || '',
       password: localStorage.getItem('password') || '',
+      passwordEncoded: localStorage.getItem('passwordEncoded') || '',
       server: localStorage.getItem('server') || '',
     };
   }
@@ -100,7 +101,7 @@ const getCoverArtUrl = (item: any, useLegacyAuth: boolean, size?: number) => {
       `${API_BASE_URL}/getCoverArt.view` +
       `?id=${item.coverArt}` +
       `&u=${auth.username}` +
-      `&p=${auth.password}` +
+      `&p=${auth.passwordEncoded}` +
       `&v=1.13.0` +
       `&c=sonixd` +
       `${size ? `&size=${size}` : ''}`
@@ -125,7 +126,7 @@ export const getDownloadUrl = (options: { id: string }, useLegacyAuth = legacyAu
       `${API_BASE_URL}/download.view` +
       `?id=${options.id}` +
       `&u=${auth.username}` +
-      `&p=${auth.password}` +
+      `&p=${auth.passwordEncoded}` +
       `&v=1.13.0` +
       `&c=sonixd`
     );
@@ -148,7 +149,7 @@ const getStreamUrl = (id: string, useLegacyAuth: boolean) => {
       `${API_BASE_URL}/stream.view` +
       `?id=${id}` +
       `&u=${auth.username}` +
-      `&p=${auth.password}` +
+      `&p=${auth.passwordEncoded}` +
       `&v=1.13.0` +
       `&c=sonixd`
     );

--- a/src/components/settings/Login.tsx
+++ b/src/components/settings/Login.tsx
@@ -38,7 +38,7 @@ const Login = () => {
     try {
       const testConnection = legacyAuth
         ? await axios.get(
-            `${cleanServerName}/rest/ping.view?v=1.13.0&c=sonixd&f=json&u=${userName}&p=${password}`
+            `${cleanServerName}/rest/ping.view?v=1.13.0&c=sonixd&f=json&u=${userName}&p=${encodeURIComponent(password)}`
           )
         : await axios.get(
             `${cleanServerName}/rest/ping.view?v=1.13.0&c=sonixd&f=json&u=${userName}&s=${salt}&t=${hash}`
@@ -64,6 +64,7 @@ const Login = () => {
     localStorage.setItem('serverType', 'subsonic');
     localStorage.setItem('username', userName);
     localStorage.setItem('password', password);
+    localStorage.setItem('passwordEncoded', encodeURIComponent(password));
     localStorage.setItem('salt', salt);
     localStorage.setItem('hash', hash);
 


### PR DESCRIPTION
This fixes passwords with special characters breaking the ability login on subsonic servers that require plaintext auth, such as supysonic and airsonic-advanced.

closes #390 